### PR TITLE
Added support for saving files to a specific directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ ENV REGISTRATION_URL="" \
     TOKEN_ENDPOINT="" \
     CLIENT_ID="" \
     CLIENT_SECRET="" \
-    DEPENDENCIES=""
+    DEPENDENCIES="" \
+    DATA_DIR="/data"
 
 # Create and declare volume for routes data
 VOLUME /data
@@ -36,4 +37,5 @@ ENTRYPOINT ["sh", "-c", "java -jar /app/app.jar \
     ${TOKEN_ENDPOINT:+--token-endpoint $TOKEN_ENDPOINT} \
     ${CLIENT_ID:+--client-id $CLIENT_ID} \
     ${CLIENT_SECRET:+--client-secret $CLIENT_SECRET} \
-    ${DEPENDENCIES:+--dependencies $DEPENDENCIES}"]
+    ${DEPENDENCIES:+--dependencies $DEPENDENCIES} \
+    ${DATA_DIR:+--data-dir $DATA_DIR}"]

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -49,6 +49,7 @@ set them so that this capability service can talk to Wanaku and register itself.
 - `--wait-seconds`: Wait time between retries (default: 1)
 - `--initial-delay`: Initial registration delay in seconds (default: 0)
 - `--period`: Period between registration attempts in seconds (default: 5)
+- `--data-dir`: Directory where downloaded files will be saved (default: `/tmp` for CLI, `/data` for Docker)
 
 ### Basic Example (Local)
 
@@ -60,12 +61,19 @@ java -jar target/camel-integration-capability-1.0-SNAPSHOT.jar \
   --registration-announce-address localhost \
   --grpc-port 9190 \
   --name camel-core \
-  --routes-path ./tests/data/routes/camel-core/promote-employee/promote-employee.camel.yaml \
-  --routes-rules ./tests/data/routes/camel-core/promote-employee/promote-employee-rules.yaml \
+  --routes-ref datastore://promote-employee.camel.yaml \
+  --rules-ref datastore://promote-employee-rules.yaml \
   --token-endpoint http://localhost:8543/realms/wanaku/ \
   --client-id wanaku-service \
-  --client-secret aBqsU3EzUPCHumf9sTK5sanxXkB0yFtv
-  --dependencies org.apache.camel:camel-http:4.14.1,org.apache.camel:camel-jackson:4.14.1
+  --client-secret aBqsU3EzUPCHumf9sTK5sanxXkB0yFtv \
+  --dependencies datastore://promote-employee-dependencies.txt \
+  --data-dir /tmp/camel-data
+```
+
+Where `promote-employee-dependencies.txt` is a text file containing the dependencies in a comma-separated list:
+
+```shell
+org.apache.camel:camel-http:4.14.2,org.apache.camel:camel-jackson:4.14.2
 ```
 
 ## Deploying the Service
@@ -142,6 +150,7 @@ secretGenerator:
 | `service-name` | Service name for registration | `my-service-name` |
 | `registration-announce-address` | Service announcement address | `auto`            |
 | `client-id` | OAuth2 client ID | `wanaku-service`  |
+| `data-dir` | Directory where downloaded files are saved | `/data`           |
 
 
 ### Deploying to the Cluster

--- a/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
+++ b/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
@@ -33,7 +33,9 @@ import io.grpc.InsecureServerCredentials;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -93,6 +95,9 @@ public class CamelToolMain implements Callable<Integer> {
     @CommandLine.Option(names = {"-d", "--dependencies"}, description = "The list of dependencies to include in runtime (comma-separated)")
     private String dependenciesList;
 
+    @CommandLine.Option(names = {"--data-dir"}, description = "The directory where downloaded files will be saved", defaultValue = "/tmp")
+    private String dataDir;
+
     public static void main(String[] args) {
         int exitCode = new CommandLine(new CamelToolMain()).execute(args);
 
@@ -150,8 +155,13 @@ public class CamelToolMain implements Callable<Integer> {
                 .secret(clientSecret)
                 .build();
 
+        // Create the data directory if it doesn't exist
+        Path dataDirPath = Paths.get(dataDir);
+        Files.createDirectories(dataDirPath);
+        LOG.info("Using data directory: {}", dataDirPath.toAbsolutePath());
+
         ServicesHttpClient httpClient = createClient(serviceConfig);
-        DataStoreDownloader downloader = new DataStoreDownloader(httpClient);
+        DataStoreDownloader downloader = new DataStoreDownloader(httpClient, dataDirPath);
         ResourceDownloaderCallback resourcesDownloaderCallback = new ResourceDownloaderCallback(downloader,
                 List.of(pathResourceRefs, pathRulesRefs1, depPath));
 

--- a/src/main/java/ai/wanaku/capability/camel/downloader/DataStoreDownloader.java
+++ b/src/main/java/ai/wanaku/capability/camel/downloader/DataStoreDownloader.java
@@ -6,7 +6,6 @@ import ai.wanaku.capabilities.sdk.services.ServicesHttpClient;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -16,9 +15,11 @@ import org.slf4j.LoggerFactory;
 public class DataStoreDownloader implements Downloader {
     private static final Logger LOG = LoggerFactory.getLogger(DataStoreDownloader.class);
     private final ServicesHttpClient servicesHttpClient;
+    private final Path dataDir;
 
-    public DataStoreDownloader(ServicesHttpClient servicesHttpClient) {
+    public DataStoreDownloader(ServicesHttpClient servicesHttpClient, Path dataDir) {
         this.servicesHttpClient = servicesHttpClient;
+        this.dataDir = dataDir;
     }
 
     @Override
@@ -47,8 +48,8 @@ public class DataStoreDownloader implements Downloader {
             // Decode from base64
             byte[] decodedData = Base64.getDecoder().decode(dataStore.getData());
 
-            // Save to current directory
-            Path filePath = Paths.get(resourceFileName);
+            // Save to the configured data directory
+            Path filePath = dataDir.resolve(resourceFileName);
             Files.write(filePath, decodedData);
             downloadedResources.put(resourceName.resourceType(), filePath);
 


### PR DESCRIPTION
## Summary by Sourcery

Add configurable data directory support for downloaded resources and update related usage and container configuration.

New Features:
- Introduce a --data-dir CLI option to control where downloaded files are stored, with sensible defaults for CLI and Docker usage.

Enhancements:
- Persist downloaded datastore resources into a configurable directory rather than the current working directory.
- Expose the data directory configuration through Docker environment variables and propagate it to the application startup.
- Refresh documentation examples to demonstrate using datastore references and a dependency list file with the new data directory option.

Documentation:
- Document the new --data-dir option and its defaults in CLI and Kubernetes usage docs, and update examples to show datastore-based routes, rules, and dependencies.