### PR TITLE
Added OIDC discovery support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,10 @@ VOLUME /data
 # Expose the gRPC port
 EXPOSE ${GRPC_PORT}
 
-# Run the application with environment variables
+# Run the application with environment variables.
+# This part uses shell parameter expansion to conditionally add command-line arguments to the Java application.
+# The Syntax: ${VARIABLE:+value} means: "If VARIABLE is set and is not null (i.e., not empty), substitute this whole expression
+# with value. Otherwise, substitute it with nothing (an empty string)."
 ENTRYPOINT ["sh", "-c", "java -jar /app/app.jar \
     ${REGISTRATION_URL:+--registration-url $REGISTRATION_URL} \
     ${REGISTRATION_ANNOUNCE_ADDRESS:+--registration-announce-address $REGISTRATION_ANNOUNCE_ADDRESS} \

--- a/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
+++ b/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
@@ -80,7 +80,7 @@ public class CamelToolMain implements Callable<Integer> {
     @CommandLine.Option(names = {"--rules-ref"}, description = "The path to the YAML file with route exposure rules (i.e.: datastore://routes-expose.yaml)")
     private String rulesRef;
 
-    @CommandLine.Option(names = {"--token-endpoint"}, description = "The base URL for the authentication", required = true)
+    @CommandLine.Option(names = {"--token-endpoint"}, description = "The base URL for the authentication", required = false)
     private String tokenEndpoint;
 
     @CommandLine.Option(names = {"--client-id"}, description = "The client ID authentication", required = true)
@@ -151,7 +151,7 @@ public class CamelToolMain implements Callable<Integer> {
                 .baseUrl(registrationUrl)
                 .serializer(new JacksonSerializer())
                 .clientId(clientId)
-                .tokenEndpoint(TokenEndpoint.fromBaseUrl(tokenEndpoint))
+                .tokenEndpoint(TokenEndpoint.autoResolve(registrationUrl, tokenEndpoint))
                 .secret(clientSecret)
                 .build();
 


### PR DESCRIPTION
## Summary by Sourcery

Relax token endpoint configuration and support automatic discovery from the registration URL.

Enhancements:
- Allow the token endpoint to be auto-resolved from the registration URL when not explicitly provided.
- Make the CLI token-endpoint option optional instead of required.
- Clarify Docker entrypoint behavior with comments explaining conditional argument expansion.