### PR TITLE
Simplify acquiring files from git

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <jackson-databind.version>2.20.1</jackson-databind.version>
         <project.main.class>ai.wanaku.capability.camel.CamelToolMain</project.main.class>
         <junit-jupiter.version>5.14.1</junit-jupiter.version>
+        <jgit.version>7.4.0.202509020913-r</jgit.version>
     </properties>
 
     <developers>
@@ -154,6 +155,12 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson-databind.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+            <version>${jgit.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/ai/wanaku/capability/camel/downloader/DownloaderFactory.java
+++ b/src/main/java/ai/wanaku/capability/camel/downloader/DownloaderFactory.java
@@ -1,0 +1,52 @@
+package ai.wanaku.capability.camel.downloader;
+
+import ai.wanaku.capabilities.sdk.services.ServicesHttpClient;
+import java.net.URI;
+import java.nio.file.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DownloaderFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(DownloaderFactory.class);
+
+    private final ServicesHttpClient servicesHttpClient;
+    private final Path dataDir;
+
+    private FileDownloader fileDownloader;
+    private DataStoreDownloader dataStoreDownloader;
+
+    public DownloaderFactory(ServicesHttpClient servicesHttpClient, Path dataDir) {
+        this.servicesHttpClient = servicesHttpClient;
+        this.dataDir = dataDir;
+    }
+
+    public Downloader getDownloader(URI uri) {
+        if (uri == null || uri.getScheme() == null) {
+            throw new IllegalArgumentException("URI and scheme cannot be null");
+        }
+
+        String scheme = uri.getScheme().toLowerCase();
+
+        return switch (scheme) {
+            case "datastore" -> getDataStoreDownloader();
+            case "file" -> getFileDownloader();
+            default -> throw new IllegalArgumentException("Unsupported URI scheme: " + scheme + ". Supported schemes: datastore://, file://");
+        };
+    }
+
+    private DataStoreDownloader getDataStoreDownloader() {
+        if (dataStoreDownloader == null) {
+            LOG.debug("Creating DataStoreDownloader instance");
+            dataStoreDownloader = new DataStoreDownloader(servicesHttpClient, dataDir);
+        }
+        return dataStoreDownloader;
+    }
+
+    private FileDownloader getFileDownloader() {
+        if (fileDownloader == null) {
+            LOG.debug("Creating FileDownloader instance");
+            fileDownloader = new FileDownloader(dataDir);
+        }
+        return fileDownloader;
+    }
+}

--- a/src/main/java/ai/wanaku/capability/camel/downloader/FileDownloader.java
+++ b/src/main/java/ai/wanaku/capability/camel/downloader/FileDownloader.java
@@ -1,0 +1,50 @@
+package ai.wanaku.capability.camel.downloader;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Downloader for local files using the file:// URI scheme.
+ * Copies files from the local filesystem to the data directory.
+ */
+public class FileDownloader implements Downloader {
+    private static final Logger LOG = LoggerFactory.getLogger(FileDownloader.class);
+    private final Path dataDir;
+
+    public FileDownloader(Path dataDir) {
+        this.dataDir = dataDir;
+    }
+
+    @Override
+    public void downloadResource(ResourceRefs<URI> resourceName, Map<ResourceType, Path> downloadedResources) throws Exception {
+        final URI fileUri = resourceName.ref();
+        LOG.debug("Processing file resource: {}", fileUri);
+
+        // Construct the Path directly from the URI to correctly handle all valid file:// URIs
+        Path sourceFile = Paths.get(fileUri);
+
+        if (!Files.exists(sourceFile)) {
+            throw new IOException("File not found: " + sourceFile.toAbsolutePath());
+        }
+
+        if (!Files.isRegularFile(sourceFile)) {
+            throw new IOException("Path is not a regular file: " + sourceFile.toAbsolutePath());
+        }
+
+        // Extract filename and copy to data directory
+        String fileName = sourceFile.getFileName().toString();
+        Path targetPath = dataDir.resolve(fileName);
+
+        Files.copy(sourceFile, targetPath, StandardCopyOption.REPLACE_EXISTING);
+        downloadedResources.put(resourceName.resourceType(), targetPath);
+
+        LOG.info("Successfully copied file resource '{}' to {}", sourceFile.toAbsolutePath(), targetPath.toAbsolutePath());
+    }
+}

--- a/src/main/java/ai/wanaku/capability/camel/downloader/ResourceDownloaderCallback.java
+++ b/src/main/java/ai/wanaku/capability/camel/downloader/ResourceDownloaderCallback.java
@@ -19,12 +19,12 @@ public class ResourceDownloaderCallback implements DiscoveryCallback {
     private final List<ResourceRefs<URI>> resources;
     private final CountDownLatch countDownLatch = new CountDownLatch(1);
 
-    private final Downloader downloader;
+    private final DownloaderFactory downloaderFactory;
     private Map<ResourceType, Path> downloadedResources = new HashMap<>();
 
-    public ResourceDownloaderCallback(Downloader downloader, List<ResourceRefs<URI>> resources) {
+    public ResourceDownloaderCallback(DownloaderFactory downloaderFactory, List<ResourceRefs<URI>> resources) {
         this.resources = resources;
-        this.downloader = downloader;
+        this.downloaderFactory = downloaderFactory;
     }
 
 
@@ -54,6 +54,7 @@ public class ResourceDownloaderCallback implements DiscoveryCallback {
 
             for (ResourceRefs<URI> resourceName : resources) {
                 try {
+                    Downloader downloader = downloaderFactory.getDownloader(resourceName.ref());
                     downloader.downloadResource(resourceName, downloadedResources);
                 } catch (WanakuWebException e) {
                     if (e.getStatusCode() == 404) {

--- a/src/main/java/ai/wanaku/capability/camel/init/GitInitializer.java
+++ b/src/main/java/ai/wanaku/capability/camel/init/GitInitializer.java
@@ -1,0 +1,58 @@
+package ai.wanaku.capability.camel.init;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Initializer that clones a Git repository during application startup.
+ * The repository is cloned to {dataDir}/cloned-repo and reused if it already exists.
+ */
+public class GitInitializer implements Initializer {
+    private static final Logger LOG = LoggerFactory.getLogger(GitInitializer.class);
+    private static final String CLONED_REPO_DIR_NAME = "cloned-repo";
+
+    private final String gitRepoUrl;
+    private final Path dataDir;
+    private Path clonedRepoPath;
+
+    public GitInitializer(String gitRepoUrl, Path dataDir) {
+        this.gitRepoUrl = gitRepoUrl;
+        this.dataDir = dataDir;
+    }
+
+    @Override
+    public void initialize() throws GitAPIException, IOException {
+        clonedRepoPath = dataDir.resolve(CLONED_REPO_DIR_NAME);
+        File clonedRepoDir = clonedRepoPath.toFile();
+
+        if (clonedRepoDir.exists()) {
+            try (Git ignored = Git.open(clonedRepoDir)) {
+                LOG.info("Reusing existing cloned repository at {}", clonedRepoPath);
+                return;
+            } catch (IOException e) {
+                throw new IOException(
+                        "Existing cloned repository at " + clonedRepoPath + " is not a valid Git repository",
+                        e);
+            }
+        }
+
+        LOG.info("Cloning git repository from {} to {}", gitRepoUrl, clonedRepoPath);
+
+        try (Git git = Git.cloneRepository()
+                .setURI(gitRepoUrl)
+                .setDirectory(clonedRepoDir)
+                .call()) {
+            LOG.info("Successfully cloned repository from {}", gitRepoUrl);
+        }
+    }
+
+    public Path getClonedRepoPath() {
+        return clonedRepoPath;
+    }
+}

--- a/src/main/java/ai/wanaku/capability/camel/init/Initializer.java
+++ b/src/main/java/ai/wanaku/capability/camel/init/Initializer.java
@@ -1,0 +1,8 @@
+package ai.wanaku.capability.camel.init;
+
+import java.net.URI;
+
+public interface Initializer {
+
+    void initialize() throws Exception;
+}

--- a/src/main/java/ai/wanaku/capability/camel/init/InitializerFactory.java
+++ b/src/main/java/ai/wanaku/capability/camel/init/InitializerFactory.java
@@ -1,0 +1,29 @@
+package ai.wanaku.capability.camel.init;
+
+import java.nio.file.Path;
+
+/**
+ * Factory for creating initializers based on the initFrom parameter.
+ * Returns a GitInitializer if a repository URL is provided, otherwise returns NoOpInitializer.
+ */
+public final class InitializerFactory {
+
+    /**
+     * Creates an appropriate initializer based on the initFrom parameter.
+     *
+     * @param initFrom Git repository URL (SSH or HTTPS), or null for no initialization
+     * @param dataDir  Directory where the repository will be cloned
+     * @return GitInitializer if initFrom is provided, NoOpInitializer otherwise
+     */
+    public static Initializer createInitializer(String initFrom, Path dataDir) {
+        final String normalizedInitFrom = initFrom == null ? null : initFrom.trim();
+        if (normalizedInitFrom == null || normalizedInitFrom.isEmpty()) {
+            return new NoOpInitializer();
+        }
+
+        // Assume it's a Git repository URL (supports both SSH and HTTPS)
+        // Examples: git@github.com:user/repo.git or https://github.com/user/repo.git
+        return new GitInitializer(normalizedInitFrom, dataDir);
+    }
+
+}

--- a/src/main/java/ai/wanaku/capability/camel/init/NoOpInitializer.java
+++ b/src/main/java/ai/wanaku/capability/camel/init/NoOpInitializer.java
@@ -1,0 +1,16 @@
+package ai.wanaku.capability.camel.init;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * No-operation initializer used when no initialization is required.
+ */
+public class NoOpInitializer implements Initializer {
+    private static final Logger LOG = LoggerFactory.getLogger(NoOpInitializer.class);
+
+    @Override
+    public void initialize() throws Exception {
+        LOG.debug("No initialization required");
+    }
+}


### PR DESCRIPTION
- Updated documentation
- Initial implementation of a resource  initializer
- Support automatically downloading files from GIT

This solves issue #26

## Summary by Sourcery

Add support for initializing route resources from Git and local files while generalizing resource acquisition via URI schemes.

New Features:
- Introduce a Git-based initializer configurable via --init-from to clone repositories at startup.
- Allow route, rules, and dependency resources to be loaded from local files using file:// URIs in addition to Wanaku DataStore references.
- Add a factory-based downloader mechanism to select the appropriate downloader implementation based on resource URI scheme.

Enhancements:
- Document new CLI options, URI schemes, and usage patterns for providing route files, including Git initialization and file-based resources.
- Refactor startup flow to run resource initialization before downloading referenced artifacts and to centralize downloader selection logic.

Build:
- Add JGit as a new dependency to support Git-based initialization.