### PR TITLE
Improve error handling when producing and/or consuming from routes

### DIFF
--- a/src/main/java/ai/wanaku/capability/camel/grpc/CamelResource.java
+++ b/src/main/java/ai/wanaku/capability/camel/grpc/CamelResource.java
@@ -11,6 +11,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import org.apache.camel.CamelContext;
 import org.apache.camel.ConsumerTemplate;
 import org.apache.camel.Route;
 import org.slf4j.Logger;
@@ -55,13 +56,11 @@ public class CamelResource extends ResourceAcquirerGrpc.ResourceAcquirerImplBase
             return;
         }
 
-        final String routeId = definition.getRoute().getId();
-        final Route route = camelManager.getCamelContext().getRoute(routeId);
-        try {
-            final String endpointUri = route.getEndpoint().getEndpointUri();
+        final CamelContext camelContext = camelManager.getCamelContext();
+        try (final ConsumerTemplate consumerTemplate = camelContext.createConsumerTemplate()) {
+            final String endpointUri = resolveEndpoint(definition, camelContext);
             LOG.info("Consuming from {} as {}", endpointUri, routeUri);
-            final ConsumerTemplate consumerTemplate =
-                    camelManager.getCamelContext().createConsumerTemplate();
+
             Object ret = consumerTemplate.receiveBody(endpointUri, 5000, String.class);
             if (ret != null) {
                 responseObserver.onNext(ResourceReply.newBuilder()
@@ -74,10 +73,32 @@ public class CamelResource extends ResourceAcquirerGrpc.ResourceAcquirerImplBase
                         .addAllContent(List.of("No response for the requested resource call"))
                         .build());
             }
-
-            responseObserver.onCompleted();
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            reportRouteFailure(responseObserver, e, definition);
+        } finally {
+            responseObserver.onCompleted();
         }
+    }
+
+    private static String resolveEndpoint(Definition definition, CamelContext camelContext) {
+        final String routeId = definition.getRoute().getId();
+        final Route route = camelContext.getRoute(routeId);
+        return route.getEndpoint().getEndpointUri();
+    }
+
+    private static void reportRouteFailure(
+            StreamObserver<ResourceReply> responseObserver, Exception e, Definition definition) {
+        final String routeId = definition.getRoute().getId();
+
+        if (LOG.isDebugEnabled()) {
+            LOG.error("Camel route {} did not produce a result: {}", routeId, e.getMessage(), e);
+        } else {
+            LOG.error("Camel route {} did not produce a result: {}", routeId, e.getMessage());
+        }
+
+        responseObserver.onNext(ResourceReply.newBuilder()
+                .setIsError(true)
+                .addAllContent(List.of(String.format("Unable to acquire resource: %s", e.getMessage())))
+                .build());
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Improve error reporting and resource management when invoking Camel routes as tools and resources.

Bug Fixes:
- Return error replies instead of propagating exceptions when Camel routes fail during tool invocation or resource acquisition.
- Ensure gRPC response observers are always completed after route processing, even on failure.

Enhancements:
- Refactor endpoint resolution for Camel routes into shared helper methods for tool invocation and resource acquisition.
- Scope Camel ProducerTemplate and ConsumerTemplate lifecycles to try-with-resources blocks to ensure proper cleanup.