### PR TITLE
feat: add --service-catalog option for loading routes from catalogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ graph TB
     E -->|Database| G[Data Sources]
     E -->|Message Queue| H[Messaging Systems]
 
-    I[DataStore Service] -.->|Route Definitions| C
-    I -.->|Rules & Dependencies| C
+    I[Service Catalog] -.->|Routes, Rules & Dependencies| C
+    J[DataStore Service] -.->|Individual Resources| C
 ```
 
 
@@ -97,7 +97,21 @@ graph TB
 
 ### Option 1: Standalone Application
 
-Run as a dedicated service with CLI configuration:
+Run as a dedicated service with CLI configuration. The recommended approach is to use a **service catalog**, which
+bundles routes, rules, and dependencies into a single versioned artifact:
+
+```bash
+java -jar camel-integration-capability-runtimes/camel-integration-capability-main/target/camel-integration-capability-main-*-jar-with-dependencies.jar \
+  --registration-url http://localhost:8080 \
+  --registration-announce-address localhost \
+  --name employee-system \
+  --service-catalog employee-system-v2 \
+  --service-catalog-system employee-system \
+  --client-id wanaku-service \
+  --client-secret your-secret
+```
+
+You can also reference individual files instead of a catalog (useful during development):
 
 ```bash
 java -jar camel-integration-capability-runtimes/camel-integration-capability-main/target/camel-integration-capability-main-*-jar-with-dependencies.jar \

--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
@@ -13,6 +13,7 @@ import io.grpc.Grpc;
 import io.grpc.InsecureServerCredentials;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
+import ai.wanaku.capabilities.sdk.api.discovery.DiscoveryCallback;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceType;
 import ai.wanaku.capabilities.sdk.common.ServicesHelper;
@@ -24,13 +25,14 @@ import ai.wanaku.capabilities.sdk.discovery.ZeroDepRegistrationManager;
 import ai.wanaku.capabilities.sdk.discovery.config.DefaultRegistrationConfig;
 import ai.wanaku.capabilities.sdk.discovery.deserializer.JacksonDeserializer;
 import ai.wanaku.capabilities.sdk.discovery.util.DiscoveryHelper;
+import ai.wanaku.capabilities.sdk.runtime.camel.downloader.DownloaderConfiguration;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.DownloaderFactory;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ExponentialBackoffRetryPolicy;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceDownloaderCallback;
-import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceDownloaderConfiguration;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceListBuilder;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceRefs;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceType;
+import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ServiceCatalogDownloaderCallback;
 import ai.wanaku.capabilities.sdk.runtime.camel.grpc.CamelHealthProbe;
 import ai.wanaku.capabilities.sdk.runtime.camel.grpc.CamelResource;
 import ai.wanaku.capabilities.sdk.runtime.camel.grpc.CamelTool;
@@ -109,8 +111,7 @@ public class CamelToolMain implements Callable<Integer> {
     @CommandLine.Option(
             names = {"--routes-ref"},
             description =
-                    "The reference path to the Apache Camel routes YAML file. Supports datastore:// and file:// schemes (e.g., datastore://routes.camel.yaml or file:///path/to/routes.yaml)",
-            required = true)
+                    "The reference path to the Apache Camel routes YAML file. Supports datastore:// and file:// schemes (e.g., datastore://routes.camel.yaml or file:///path/to/routes.yaml)")
     private String routesRef;
 
     @CommandLine.Option(
@@ -167,6 +168,17 @@ public class CamelToolMain implements Callable<Integer> {
     private String initFrom;
 
     @CommandLine.Option(
+            names = {"--service-catalog"},
+            description =
+                    "The name of the service catalog to use. Mutually exclusive with --routes-ref, --rules-ref, and --dependencies. Requires --service-catalog-system.")
+    private String serviceCatalog;
+
+    @CommandLine.Option(
+            names = {"--service-catalog-system"},
+            description = "The system name within the service catalog to use (e.g., employee-check)")
+    private String serviceCatalogSystem;
+
+    @CommandLine.Option(
             names = {"--fail-fast"},
             description = "Fail fast if route loading fails. If false, log and continue.",
             defaultValue = "false")
@@ -179,9 +191,7 @@ public class CamelToolMain implements Callable<Integer> {
     }
 
     public ZeroDepRegistrationManager newRegistrationManager(
-            ServiceTarget serviceTarget,
-            ResourceDownloaderCallback resourcesDownloaderCallback,
-            ServiceConfig serviceConfig) {
+            ServiceTarget serviceTarget, DiscoveryCallback discoveryCallback, ServiceConfig serviceConfig) {
         DiscoveryServiceHttpClient discoveryServiceHttpClient = new DiscoveryServiceHttpClient(serviceConfig);
 
         final DefaultRegistrationConfig registrationConfig = DefaultRegistrationConfig.Builder.newBuilder()
@@ -195,7 +205,7 @@ public class CamelToolMain implements Callable<Integer> {
         ZeroDepRegistrationManager registrationManager = new ZeroDepRegistrationManager(
                 discoveryServiceHttpClient, serviceTarget, registrationConfig, new JacksonDeserializer());
 
-        registrationManager.addCallBack(resourcesDownloaderCallback);
+        registrationManager.addCallBack(discoveryCallback);
         registrationManager.start();
 
         return registrationManager;
@@ -213,6 +223,8 @@ public class CamelToolMain implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
         LOG.info("Camel Integration Capability {} is starting", VersionHelper.VERSION);
+
+        validateOptions();
 
         // Create the data directory first (needed by initializers)
         Path dataDirPath = Paths.get(dataDir);
@@ -232,33 +244,52 @@ public class CamelToolMain implements Callable<Integer> {
                 .build();
 
         ServicesHttpClient httpClient = createClient(serviceConfig);
+
         DownloaderFactory downloaderFactory = new DownloaderFactory(httpClient, dataDirPath);
 
-        List<ResourceRefs<URI>> resources = ResourceListBuilder.newBuilder()
-                .addRoutesRef(routesRef)
-                .addRulesRef(rulesRef)
-                .addDependenciesRef(dependenciesRef)
-                .build();
-
-        ResourceDownloaderConfiguration downloaderConfig = ResourceDownloaderConfiguration.newBuilder()
+        DownloaderConfiguration downloaderConfig = DownloaderConfiguration.newBuilder()
                 .retryPolicy(ExponentialBackoffRetryPolicy.newBuilder()
                         .maxRetries(retries)
                         .build())
                 .build();
 
-        ResourceDownloaderCallback resourcesDownloaderCallback =
-                new ResourceDownloaderCallback(downloaderFactory, resources, downloaderConfig);
+        final Map<ResourceType, Path> downloadedResources;
+        final ZeroDepRegistrationManager registrationManager;
 
-        final ServiceTarget toolInvokerTarget = newServiceTargetTarget();
-        ZeroDepRegistrationManager registrationManager =
-                newRegistrationManager(toolInvokerTarget, resourcesDownloaderCallback, serviceConfig);
+        if (serviceCatalog != null) {
+            ServiceCatalogDownloaderCallback catalogCallback = new ServiceCatalogDownloaderCallback(
+                    downloaderFactory, serviceCatalog, serviceCatalogSystem, downloaderConfig);
 
-        if (!resourcesDownloaderCallback.waitForDownloads()) {
-            LOG.error("Failed to download required resources (check the logs)");
-            return 1;
+            final ServiceTarget toolInvokerTarget = newServiceTargetTarget();
+            registrationManager = newRegistrationManager(toolInvokerTarget, catalogCallback, serviceConfig);
+
+            if (!catalogCallback.waitForDownloads()) {
+                LOG.error("Failed to download service catalog resources (check the logs)");
+                return 1;
+            }
+
+            downloadedResources = catalogCallback.getDownloadedResources();
+        } else {
+            List<ResourceRefs<URI>> resources = ResourceListBuilder.newBuilder()
+                    .addRoutesRef(routesRef)
+                    .addRulesRef(rulesRef)
+                    .addDependenciesRef(dependenciesRef)
+                    .build();
+
+            ResourceDownloaderCallback resourcesDownloaderCallback =
+                    new ResourceDownloaderCallback(downloaderFactory, resources, downloaderConfig);
+
+            final ServiceTarget toolInvokerTarget = newServiceTargetTarget();
+            registrationManager = newRegistrationManager(toolInvokerTarget, resourcesDownloaderCallback, serviceConfig);
+
+            if (!resourcesDownloaderCallback.waitForDownloads()) {
+                LOG.error("Failed to download required resources (check the logs)");
+                return 1;
+            }
+
+            downloadedResources = resourcesDownloaderCallback.getDownloadedResources();
         }
 
-        final Map<ResourceType, Path> downloadedResources = resourcesDownloaderCallback.getDownloadedResources();
         WanakuCamelManager.RouteLoadingFailurePolicy policy = failFast
                 ? WanakuCamelManager.RouteLoadingFailurePolicy.FAIL_FAST
                 : WanakuCamelManager.RouteLoadingFailurePolicy.LOG_AND_CONTINUE;
@@ -267,7 +298,6 @@ public class CamelToolMain implements Callable<Integer> {
         McpSpec mcpSpec = createMcpSpec(httpClient, downloadedResources);
 
         try {
-
             final ServerBuilder<?> serverBuilder =
                     Grpc.newServerBuilderForPort(grpcPort, InsecureServerCredentials.create());
             final Server server = serverBuilder
@@ -284,6 +314,27 @@ public class CamelToolMain implements Callable<Integer> {
         }
 
         return 0;
+    }
+
+    private void validateOptions() {
+        boolean hasServiceCatalog = serviceCatalog != null && !serviceCatalog.isBlank();
+        boolean hasIndividualRefs = routesRef != null || rulesRef != null || dependenciesRef != null;
+
+        if (hasServiceCatalog && hasIndividualRefs) {
+            throw new CommandLine.ParameterException(
+                    new CommandLine(this),
+                    "--service-catalog is mutually exclusive with --routes-ref, --rules-ref, and --dependencies");
+        }
+
+        if (hasServiceCatalog && (serviceCatalogSystem == null || serviceCatalogSystem.isBlank())) {
+            throw new CommandLine.ParameterException(
+                    new CommandLine(this), "--service-catalog-system is required when --service-catalog is used");
+        }
+
+        if (!hasServiceCatalog && (routesRef == null || routesRef.isBlank())) {
+            throw new CommandLine.ParameterException(
+                    new CommandLine(this), "Either --routes-ref or --service-catalog must be provided");
+        }
     }
 
     public McpSpec createMcpSpec(ServicesHttpClient servicesClient, Map<ResourceType, Path> downloadedResources) {

--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/WanakuCamelManager.java
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/WanakuCamelManager.java
@@ -3,8 +3,10 @@ package ai.wanaku.capability.camel;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import org.apache.camel.CamelContext;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.slf4j.Logger;
@@ -35,8 +37,8 @@ public class WanakuCamelManager {
             String repositoriesList,
             RouteLoadingFailurePolicy routeLoadingFailurePolicy) {
         this.repositoriesList = repositoriesList;
-        this.routeLoadingFailurePolicy = Objects.requireNonNull(routeLoadingFailurePolicy,
-                "RouteLoadingFailurePolicy must not be null");
+        this.routeLoadingFailurePolicy =
+                Objects.requireNonNull(routeLoadingFailurePolicy, "RouteLoadingFailurePolicy must not be null");
         context = new DefaultCamelContext();
 
         this.routesPath = downloadedResources.get(ResourceType.ROUTES_REF).toString();
@@ -44,7 +46,11 @@ public class WanakuCamelManager {
             String dependenciesPath =
                     downloadedResources.get(ResourceType.DEPENDENCY_REF).toString();
             try {
-                this.dependenciesList = Files.readString(Path.of(dependenciesPath));
+                final List<String> depLines = Files.readAllLines(Path.of(dependenciesPath));
+                final Optional<String> firstDepLine =
+                        depLines.stream().filter(l -> !l.startsWith("#")).findFirst();
+                this.dependenciesList = firstDepLine.orElse(null);
+
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/WanakuCamelManager.java
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/WanakuCamelManager.java
@@ -12,6 +12,7 @@ import org.apache.camel.impl.DefaultCamelContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceType;
+import ai.wanaku.capabilities.sdk.runtime.camel.exceptions.RouteLoadingException;
 import ai.wanaku.capabilities.sdk.runtime.camel.util.WanakuRoutesLoader;
 
 public class WanakuCamelManager {
@@ -65,16 +66,17 @@ public class WanakuCamelManager {
         WanakuRoutesLoader routesLoader = new WanakuRoutesLoader(dependenciesList, repositoriesList);
 
         String routeFileUrl = Path.of(routesPath).toUri().toString();
-        int routesBeforeLoad = context.getRoutes().size();
-        routesLoader.loadRoute(context, routeFileUrl);
-        int loadedRoutes = context.getRoutes().size() - routesBeforeLoad;
-        if (loadedRoutes <= 0) {
-            String message = "No Camel routes were loaded from " + routeFileUrl;
-            if (routeLoadingFailurePolicy == RouteLoadingFailurePolicy.FAIL_FAST) {
-                throw new IllegalStateException(message);
-            }
 
-            LOG.warn("{} Continuing because route loading policy is LOG_AND_CONTINUE.", message);
+        try {
+            routesLoader.loadRoute(context, routeFileUrl);
+        } catch (RouteLoadingException e) {
+            if (routeLoadingFailurePolicy == RouteLoadingFailurePolicy.FAIL_FAST) {
+                throw e;
+            } else {
+                LOG.warn(
+                        "Failed to load routes, but continuing because route loading policy is LOG_AND_CONTINUE: {}",
+                        e.getMessage());
+            }
         }
         context.start();
     }

--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/test/java/ai/wanaku/capability/camel/WanakuCamelRouteLoaderFailIT.java
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/test/java/ai/wanaku/capability/camel/WanakuCamelRouteLoaderFailIT.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.wanaku.capability.camel;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceType;
+import ai.wanaku.capabilities.sdk.runtime.camel.exceptions.RouteLoadingException;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class WanakuCamelRouteLoaderFailIT {
+
+    @Test
+    void throwsErrorOnFailFast() {
+        Path routesFile = Paths.get("src", "test", "resources", "test-routes-with-errors.camel.yaml");
+        Path dependenciesFile = Paths.get("src", "test", "resources", "test-routes-dependencies.txt");
+
+        Map<ResourceType, Path> downloadedResources = Map.of(
+                ResourceType.ROUTES_REF, routesFile,
+                ResourceType.DEPENDENCY_REF, dependenciesFile);
+
+        assertThrows(RouteLoadingException.class, () -> new WanakuCamelManager(downloadedResources, null));
+    }
+
+    @Test
+    void doesNotThrowErrorOnFailFast() {
+        Path routesFile = Paths.get("src", "test", "resources", "test-routes-with-errors.camel.yaml");
+        Path dependenciesFile = Paths.get("src", "test", "resources", "test-routes-dependencies.txt");
+
+        Map<ResourceType, Path> downloadedResources = Map.of(
+                ResourceType.ROUTES_REF, routesFile,
+                ResourceType.DEPENDENCY_REF, dependenciesFile);
+
+        assertDoesNotThrow(() -> new WanakuCamelManager(
+                downloadedResources, null, WanakuCamelManager.RouteLoadingFailurePolicy.LOG_AND_CONTINUE));
+    }
+}

--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/test/java/ai/wanaku/capability/camel/WanakuCamelRouteLoaderIT.java
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/test/java/ai/wanaku/capability/camel/WanakuCamelRouteLoaderIT.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class WanakuCamelRouteLoaderIT {
@@ -88,14 +87,6 @@ class WanakuCamelRouteLoaderIT {
     }
 
     @Test
-    void gsonDataFormatIsAvailableThroughDataFormatResolver() {
-        CamelContext context = camelManager.getCamelContext();
-        assertNotNull(
-                context.resolveDataFormat("gson"),
-                "JSON data format should be available through DependencyDownloaderDataFormatResolver");
-    }
-
-    @Test
     void jsonPathLanguageIsAvailableThroughLanguageResolver() {
         CamelContext context = camelManager.getCamelContext();
         assertNotNull(
@@ -140,25 +131,6 @@ class WanakuCamelRouteLoaderIT {
         assertTrue(
                 expectedPattern.matcher(result).matches(),
                 "Result should match pattern [a-z]{5}\\d{3}, but was: " + result);
-    }
-
-    @Test
-    void emptyRouteDefinitionsFailFast() {
-        Path routesFile = Paths.get("src", "test", "resources", "empty-routes.camel.yaml");
-        Path dependenciesFile = Paths.get("src", "test", "resources", "test-routes-dependencies.txt");
-
-        Map<ResourceType, Path> downloadedResources = Map.of(
-                ResourceType.ROUTES_REF, routesFile,
-                ResourceType.DEPENDENCY_REF, dependenciesFile);
-
-        IllegalStateException exception = assertThrows(
-                IllegalStateException.class,
-                () -> new WanakuCamelManager(downloadedResources, null),
-                "An empty route file should fail fast");
-
-        assertTrue(
-                exception.getMessage().contains("No Camel routes were loaded"),
-                "Exception should explain that no routes were loaded");
     }
 
     @Test

--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/test/java/ai/wanaku/capability/camel/WanakuCamelRouteLoaderIT.java
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/test/java/ai/wanaku/capability/camel/WanakuCamelRouteLoaderIT.java
@@ -29,9 +29,9 @@ import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceType;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class WanakuCamelRouteLoaderIT {
@@ -171,9 +171,7 @@ class WanakuCamelRouteLoaderIT {
                 ResourceType.DEPENDENCY_REF, dependenciesFile);
 
         WanakuCamelManager lenientCamelManager = new WanakuCamelManager(
-                downloadedResources,
-                null,
-                WanakuCamelManager.RouteLoadingFailurePolicy.LOG_AND_CONTINUE);
+                downloadedResources, null, WanakuCamelManager.RouteLoadingFailurePolicy.LOG_AND_CONTINUE);
 
         try {
             CamelContext context = lenientCamelManager.getCamelContext();

--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/test/resources/test-routes-with-errors.camel.yaml
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/test/resources/test-routes-with-errors.camel.yaml
@@ -1,0 +1,53 @@
+- route:
+    id: test-component-resolver
+    from:
+      uri: direct:test-component
+      steps:
+        - to: https://api.example.com/test
+
+- route:
+    id: test-dataformat-resolver
+    from:
+      udri: direct:test-dataformat
+      steps:
+        - marshal:
+            json: {}
+        - log: "Marshalled to JSON"
+
+- route:
+    id: test-language-resolver
+    from:
+      uri: direct:test-language
+      steps:
+        - setBody:
+            jsonpath: "$.employee.name"
+        - log: "Extracted name using JSONPath: ${body}"
+
+- route:
+    id: test-transformer-resolver
+    from:
+      uri: direct:test-transformer
+      steps:
+        - transform:
+            jq: ".employee"
+        - log: "Transformed using JQ"
+
+- route:
+    id: test-uri-factory-resolver
+    from:
+      uri: direct:test-uri-factory
+      steps:
+        - toD: "kafka:${header.topic}"
+
+- route:
+    id: test-groovy-with-dependency
+    from:
+      uri: direct:test-groovy
+      steps:
+        - setBody:
+            groovy:
+              expression: |
+                import com.github.curiousoddman.rgxgen.RgxGen
+                def rgxGen = new RgxGen('[a-z]{5}\\d{3}')
+                return rgxGen.generate()
+        - log: "Generated random string: ${body}"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -41,13 +41,18 @@ set them so that this capability service can talk to Wanaku and register itself.
 
 - `--registration-url`: URL of the Wanaku discovery service
 - `--registration-announce-address`: Address to announce for service discovery
-- `--routes-ref`: Reference to the Apache Camel routes YAML file. Supports `datastore://` and `file://` schemes
-- `--token-endpoint`: OAuth2/OIDC token endpoint base URL
 - `--client-id`: OAuth2 client ID for authentication
 - `--client-secret`: OAuth2 client secret for authentication
 
+One of the following is required to provide routes:
+
+- `--service-catalog`: Name of the service catalog to load routes, rules, and dependencies from (recommended). Requires `--service-catalog-system`
+- `--routes-ref`: Reference to the Apache Camel routes YAML file. Supports `datastore://` and `file://` schemes
+
 ### Optional Parameters
 
+- `--service-catalog-system`: The system name within the service catalog (required when using `--service-catalog`)
+- `--token-endpoint`: OAuth2/OIDC token endpoint base URL
 - `--rules-ref`: Reference to the YAML file with route exposure rules. Supports `datastore://` and `file://` schemes
 - `--dependencies`: Comma-separated list of dependencies. Supports `datastore://` and `file://` schemes
 - `--init-from`: Git repository URL to clone during initialization (SSH or HTTPS format)
@@ -59,6 +64,10 @@ set them so that this capability service can talk to Wanaku and register itself.
 - `--period`: Period between registration attempts in seconds (default: 5)
 - `--data-dir`: Directory where downloaded files will be saved (default: `/tmp` for CLI, `/data` for Docker)
 
+> [NOTE]
+> `--service-catalog` is mutually exclusive with `--routes-ref`, `--rules-ref`, and `--dependencies`.
+> When using a service catalog, all three resources are extracted from the catalog automatically.
+
 ### URI Schemes
 
 The service supports multiple URI schemes for resource references:
@@ -66,9 +75,30 @@ The service supports multiple URI schemes for resource references:
 - **datastore://**: Fetches files from the Wanaku DataStore service.
 - **file://**: References local files (absolute paths required)
 
-### Basic Example (Local)
+### Basic Example Using a Service Catalog (Recommended)
 
-For local development with a Wanaku stack:
+Service catalogs are the recommended way to provide routes to the capability. A service catalog bundles routes,
+rules, and dependencies into a single versioned artifact stored in Wanaku. This simplifies configuration and
+makes it easy to update all resources at once.
+
+```bash
+java -jar target/camel-integration-capability-main-0.1.0-jar-with-dependencies.jar \
+  --registration-url http://localhost:8080 \
+  --registration-announce-address localhost \
+  --grpc-port 9190 \
+  --name employee-system \
+  --service-catalog employee-system-v2 \
+  --service-catalog-system employee-system \
+  --client-id wanaku-service \
+  --client-secret aBqsU3EzUPCHumf9sTK5sanxXkB0yFtv
+```
+
+With service catalogs, `--routes-ref`, `--rules-ref`, and `--dependencies` are not needed — the catalog
+contains all required resources for the given system.
+
+### Basic Example Using Individual References
+
+For cases where routes, rules, and dependencies are managed separately (e.g., during development):
 
 ```bash
 java -jar target/camel-integration-capability-main-0.1.0-jar-with-dependencies.jar \
@@ -95,6 +125,8 @@ org.apache.camel:camel-http:4.14.2,org.apache.camel:camel-jackson:4.14.2
 
 The service can be deployed to Kubernetes or OpenShift using the Wanaku's operator. 
 
+##### Using a Service Catalog (Recommended)
+
 ```yaml
 apiVersion: "wanaku.ai/v1alpha1"
 kind: Wanaku
@@ -103,7 +135,6 @@ metadata:
 spec:
   auth:
     authServer: http://address-of-the-keycloak-instance
-    # Address of the proxy (could be the same as the auth server - default) or "auto" (for using Wanaku as the proxy via OIDC proxy)
     authProxy: "auto"
   router:
     image: quay.io/wanaku/wanaku-router-backend:latest
@@ -116,40 +147,59 @@ spec:
     - name: employee-system
       type: camel-integration-capability
       image: quay.io/wanaku/camel-integration-capability:latest
-      # When using a camel integration capability, must always set the routes and rules references
       env:
-        # Reference to the Camel routes YAML file (supports datastore:// and file:// schemes)
+        - name: SERVICE_CATALOG
+          value: "employee-system-v2"
+        - name: SERVICE_CATALOG_SYSTEM
+          value: "employee-system"
+```
+
+##### Using Individual References
+
+```yaml
+apiVersion: "wanaku.ai/v1alpha1"
+kind: Wanaku
+metadata:
+  name: wanaku-dev
+spec:
+  auth:
+    authServer: http://address-of-the-keycloak-instance
+    authProxy: "auto"
+  router:
+    image: quay.io/wanaku/wanaku-router-backend:latest
+    imagePullPolicy: Always
+  secrets:
+    oidcCredentialsSecret: <credentials-go-here>
+  capabilities:
+    - name: wanaku-http
+      image: quay.io/wanaku/wanaku-tool-service-http:latest
+    - name: employee-system
+      type: camel-integration-capability
+      image: quay.io/wanaku/camel-integration-capability:latest
+      env:
         - name: ROUTES_REF
           value: "datastore://employee-backend.camel.yaml"
-        # Reference to the route exposure rules YAML (supports datastore:// and file:// schemes)
         - name: RULES_REF
           value: "datastore://employee-backend-rules.yaml"
-        # Reference to dependencies file (supports datastore:// and file:// schemes)
         - name: DEPENDENCIES
           value: "datastore://employee-backend-dependencies.txt"
 ```
 
-#### Required Configuration
+#### Configuration Reference
 
-| Parameter    | Description                                                | Example                        |
-|--------------|------------------------------------------------------------|--------------------------------|
-| `ROUTES_REF` | Reference to the Camel routes YAML file                    | `datastore://route.camel.yaml` |
-| `RULES_REF`  | Reference to the route exposure rules YAML                 | `datastore://route-rules.yaml` |
-| `DEPENDENCIES` | Reference to a text file containing a list of dependencies | `datastore://dependencies.txt` |
-
-> [NOTE]
-> See the running documentation below for details on each of these.
-
-#### Optional Configuration
-
-| Parameter      | Description                                | Example                       |
-|----------------|--------------------------------------------|-------------------------------|
-| `INIT_FROM`    | Git repository URL to clone during startup | `git@github.com:org/repo.git` |
-| `DATA_DIR`     | Directory where downloaded files are saved | `/data`                       |
-| `REPOSITORIES` | Additional Maven repositories to use       | `http://repo.com`             |
+| Parameter                | Description                                                | Example                        |
+|--------------------------|------------------------------------------------------------|--------------------------------|
+| `SERVICE_CATALOG`        | Name of the service catalog (recommended)                  | `employee-system-v2`           |
+| `SERVICE_CATALOG_SYSTEM` | System name within the catalog (required with above)       | `employee-system`              |
+| `ROUTES_REF`             | Reference to the Camel routes YAML file                    | `datastore://route.camel.yaml` |
+| `RULES_REF`              | Reference to the route exposure rules YAML                 | `datastore://route-rules.yaml` |
+| `DEPENDENCIES`           | Reference to a text file containing a list of dependencies | `datastore://dependencies.txt` |
+| `INIT_FROM`              | Git repository URL to clone during startup                 | `git@github.com:org/repo.git`  |
+| `DATA_DIR`               | Directory where downloaded files are saved                 | `/data`                        |
+| `REPOSITORIES`           | Additional Maven repositories to use                       | `http://repo.com`              |
 
 > [NOTE]
-> See the running documentation below for details on each of these.
+> `SERVICE_CATALOG` is mutually exclusive with `ROUTES_REF`, `RULES_REF`, and `DEPENDENCIES`.
 
 ### Troubleshooting
 
@@ -445,17 +495,50 @@ tools or MCP resources. To do so, the capability needs to have access to the fil
 
 Route files can be provided to the capability using one of the following methods:
 
-1. **From Wanaku's Data Store**: This uses Wanaku's Data Store to download files automatically after registration.
-2. **Built-in Git initialization**: Use `--init-from` to clone a repository during startup
-3. **Init container**: Use a separate container to clone files before the main container starts (see example below)
-4. **Volume mounts**: Mount ConfigMaps or persistent volumes containing route files
+1. **From a Wanaku Service Catalog** (recommended): Bundles routes, rules, and dependencies into a single versioned artifact
+2. **From Wanaku's Data Store**: Uses Wanaku's Data Store to download individual files after registration
+3. **Built-in Git initialization**: Use `--init-from` to clone a repository during startup
+4. **Init container**: Use a separate container to clone files before the main container starts (see example below)
+5. **Volume mounts**: Mount ConfigMaps or persistent volumes containing route files
+
+### Using a Service Catalog
+
+This is the recommended way to obtain route files. A service catalog is a versioned ZIP archive stored in Wanaku
+that bundles all resources (routes, rules, and optionally dependencies) for one or more systems. Using a catalog
+simplifies deployment because a single `--service-catalog` parameter replaces `--routes-ref`, `--rules-ref`, and
+`--dependencies`.
+
+The catalog ZIP must contain an `index.properties` file mapping system names to their resources:
+
+```properties
+catalog.name=employee-system-v2
+catalog.services=employee-system
+catalog.routes.employee-system=employee-system/routes.camel.yaml
+catalog.rules.employee-system=employee-system/rules.wanaku-rules.yaml
+catalog.dependencies.employee-system=employee-system/dependencies.txt
+```
+
+When running manually:
+
+```bash
+java -jar target/camel-integration-capability-main-0.1.0-jar-with-dependencies.jar \
+  --registration-url http://localhost:8080 \
+  --registration-announce-address localhost \
+  --grpc-port 9190 \
+  --name employee-system \
+  --service-catalog employee-system-v2 \
+  --service-catalog-system employee-system \
+  --client-id wanaku-service \
+  --client-secret aBqsU3EzUPCHumf9sTK5sanxXkB0yFtv
+```
+
+The capability will download the catalog after registration, extract the files for the specified system,
+and start serving the routes automatically. Failed downloads are retried with exponential backoff.
 
 ### Using Wanaku's Data Store
 
-This is the recommended way to obtain the route files. In this mode, the capability downloads files
-directly from Wanaku after its registration is complete.
-
-When running manually, the command looks like this:
+In this mode, the capability downloads individual files directly from Wanaku after registration.
+This is useful during development or when you need fine-grained control over each resource.
 
 ```bash
 java -jar target/camel-integration-capability-main-0.1.0-jar-with-dependencies.jar \


### PR DESCRIPTION
## Summary
- Add `--service-catalog` and `--service-catalog-system` CLI options as an alternative to `--routes-ref`/`--rules-ref`/`--dependencies`
- When set, the CIC fetches a catalog ZIP from the router, extracts the specified system's files, and uses them as routes/rules/dependencies
- Options are mutually exclusive: using `--service-catalog` with individual refs produces an error

## Test plan
- [x] `mvn verify` passes
- [ ] Launch CIC with `--service-catalog employee-systems --service-catalog-system employee-check` and verify routes are loaded correctly
- [ ] Verify error when combining `--service-catalog` with `--routes-ref`

## Summary by Sourcery

Add support for loading Camel integration resources from a service catalog as an alternative to individual route/rule/dependency references.

New Features:
- Introduce --service-catalog and --service-catalog-system CLI options to load routes, rules, and dependencies from a named service catalog and system.

Enhancements:
- Allow running without an explicit --routes-ref when a service catalog is provided, enforcing mutual exclusivity and required option combinations.
- Integrate service catalog downloads and extraction into the startup flow, wiring extracted resources into the existing Camel and MCP initialization.