### PR TITLE
Add retry support with exponential backoff for resource downloads

### DIFF
--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
@@ -25,7 +25,9 @@ import ai.wanaku.capabilities.sdk.discovery.config.DefaultRegistrationConfig;
 import ai.wanaku.capabilities.sdk.discovery.deserializer.JacksonDeserializer;
 import ai.wanaku.capabilities.sdk.discovery.util.DiscoveryHelper;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.DownloaderFactory;
+import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ExponentialBackoffRetryPolicy;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceDownloaderCallback;
+import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceDownloaderConfiguration;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceListBuilder;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceRefs;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceType;
@@ -233,8 +235,14 @@ public class CamelToolMain implements Callable<Integer> {
                 .addDependenciesRef(dependenciesRef)
                 .build();
 
+        ResourceDownloaderConfiguration downloaderConfig = ResourceDownloaderConfiguration.newBuilder()
+                .retryPolicy(ExponentialBackoffRetryPolicy.newBuilder()
+                        .maxRetries(retries)
+                        .build())
+                .build();
+
         ResourceDownloaderCallback resourcesDownloaderCallback =
-                new ResourceDownloaderCallback(downloaderFactory, resources);
+                new ResourceDownloaderCallback(downloaderFactory, resources, downloaderConfig);
 
         final ServiceTarget toolInvokerTarget = newServiceTargetTarget();
         ZeroDepRegistrationManager registrationManager =


### PR DESCRIPTION
## Summary

- Wires exponential backoff retry into `CamelToolMain` using the existing `--retries` CLI option
- Resource downloads now retry on 5xx server errors and transient network exceptions
- No retry on 4xx client errors or local file I/O errors
- Based on wanaku-capabilities-java-sdk [PR #104](https://github.com/wanaku-ai/wanaku-capabilities-java-sdk/pull/104)

## Test plan

- [ ] Verify build passes (`mvn verify`)
- [ ] Verify downloads succeed on first attempt (no retry triggered)
- [ ] Simulate a 5xx server error and verify exponential backoff retry occurs
- [ ] Simulate a 404 error and verify no retry is attempted

## Summary by Sourcery

Enhancements:
- Pass a ResourceDownloaderConfiguration with an ExponentialBackoffRetryPolicy, driven by the existing retries CLI option, into the ResourceDownloaderCallback for resource downloads.