### PR TITLE
Fix #82: start gRPC server before registration to fix health check race condition

### DIFF
--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
@@ -14,6 +14,7 @@ import io.grpc.InsecureServerCredentials;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import ai.wanaku.capabilities.sdk.api.discovery.DiscoveryCallback;
+import ai.wanaku.capabilities.sdk.api.discovery.RegistrationManager;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceType;
 import ai.wanaku.capabilities.sdk.common.ServicesHelper;
@@ -33,7 +34,6 @@ import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceListBuilder;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceRefs;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceType;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ServiceCatalogDownloaderCallback;
-import ai.wanaku.capabilities.sdk.runtime.camel.grpc.CamelHealthProbe;
 import ai.wanaku.capabilities.sdk.runtime.camel.grpc.CamelResource;
 import ai.wanaku.capabilities.sdk.runtime.camel.grpc.CamelTool;
 import ai.wanaku.capabilities.sdk.runtime.camel.grpc.ProvisionBase;
@@ -254,14 +254,12 @@ public class CamelToolMain implements Callable<Integer> {
                 .build();
 
         final Map<ResourceType, Path> downloadedResources;
-        final ZeroDepRegistrationManager registrationManager;
 
         if (serviceCatalog != null) {
             ServiceCatalogDownloaderCallback catalogCallback = new ServiceCatalogDownloaderCallback(
                     downloaderFactory, serviceCatalog, serviceCatalogSystem, downloaderConfig);
 
-            final ServiceTarget toolInvokerTarget = newServiceTargetTarget();
-            registrationManager = newRegistrationManager(toolInvokerTarget, catalogCallback, serviceConfig);
+            catalogCallback.onRegistration(null, null);
 
             if (!catalogCallback.waitForDownloads()) {
                 LOG.error("Failed to download service catalog resources (check the logs)");
@@ -279,8 +277,7 @@ public class CamelToolMain implements Callable<Integer> {
             ResourceDownloaderCallback resourcesDownloaderCallback =
                     new ResourceDownloaderCallback(downloaderFactory, resources, downloaderConfig);
 
-            final ServiceTarget toolInvokerTarget = newServiceTargetTarget();
-            registrationManager = newRegistrationManager(toolInvokerTarget, resourcesDownloaderCallback, serviceConfig);
+            resourcesDownloaderCallback.onRegistration(null, null);
 
             if (!resourcesDownloaderCallback.waitForDownloads()) {
                 LOG.error("Failed to download required resources (check the logs)");
@@ -297,17 +294,36 @@ public class CamelToolMain implements Callable<Integer> {
 
         McpSpec mcpSpec = createMcpSpec(httpClient, downloadedResources);
 
-        try {
-            final ServerBuilder<?> serverBuilder =
-                    Grpc.newServerBuilderForPort(grpcPort, InsecureServerCredentials.create());
-            final Server server = serverBuilder
-                    .addService(new CamelTool(camelManager.getCamelContext(), mcpSpec))
-                    .addService(new CamelResource(camelManager.getCamelContext(), mcpSpec))
-                    .addService(new ProvisionBase(name))
-                    .addService(new CamelHealthProbe(camelManager.getCamelContext(), registrationManager.getTarget()))
-                    .build();
+        DeferredHealthProbe healthProbe = new DeferredHealthProbe(camelManager.getCamelContext());
 
-            server.start();
+        final ServerBuilder<?> serverBuilder =
+                Grpc.newServerBuilderForPort(grpcPort, InsecureServerCredentials.create());
+        final Server server = serverBuilder
+                .addService(new CamelTool(camelManager.getCamelContext(), mcpSpec))
+                .addService(new CamelResource(camelManager.getCamelContext(), mcpSpec))
+                .addService(new ProvisionBase(name))
+                .addService(healthProbe)
+                .build();
+
+        server.start();
+
+        final ServiceTarget toolInvokerTarget = newServiceTargetTarget();
+        DiscoveryCallback registrationCallback = new DiscoveryCallback() {
+            @Override
+            public void onRegistration(RegistrationManager manager, ServiceTarget target) {
+                healthProbe.setTarget(target);
+            }
+
+            @Override
+            public void onPing(RegistrationManager manager, ServiceTarget target, int status) {}
+
+            @Override
+            public void onDeregistration(RegistrationManager manager, ServiceTarget target, int status) {}
+        };
+        final ZeroDepRegistrationManager registrationManager =
+                newRegistrationManager(toolInvokerTarget, registrationCallback, serviceConfig);
+
+        try {
             server.awaitTermination();
         } finally {
             registrationManager.deregister();

--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/DeferredHealthProbe.java
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/DeferredHealthProbe.java
@@ -1,0 +1,78 @@
+package ai.wanaku.capability.camel;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.ServiceStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
+import ai.wanaku.core.exchange.v1.HealthProbeGrpc;
+import ai.wanaku.core.exchange.v1.HealthProbeReply;
+import ai.wanaku.core.exchange.v1.HealthProbeRequest;
+import ai.wanaku.core.exchange.v1.RuntimeStatus;
+
+/**
+ * A health probe that supports deferred target initialization.
+ * <p>
+ * Unlike {@link ai.wanaku.capabilities.sdk.runtime.camel.grpc.CamelHealthProbe},
+ * this probe does not require a valid service target at construction time.
+ * Before the target is set, health probes respond with the CamelContext status
+ * without validating the request ID. After {@link #setTarget(ServiceTarget)} is
+ * called, full ID validation is performed.
+ * <p>
+ * This allows the gRPC server to start and respond to health checks before
+ * registration with the router completes, preventing the race condition where
+ * the router's immediate post-registration health check fails because the
+ * gRPC server isn't running yet.
+ */
+public class DeferredHealthProbe extends HealthProbeGrpc.HealthProbeImplBase {
+    private static final Logger LOG = LoggerFactory.getLogger(DeferredHealthProbe.class);
+
+    private final CamelContext camelContext;
+    private volatile ServiceTarget target;
+
+    public DeferredHealthProbe(CamelContext camelContext) {
+        this.camelContext = camelContext;
+    }
+
+    public void setTarget(ServiceTarget target) {
+        this.target = target;
+    }
+
+    RuntimeStatus mapStatus(ServiceStatus serviceStatus) {
+        switch (serviceStatus) {
+            case Initializing, Initialized, Starting -> {
+                return RuntimeStatus.RUNTIME_STATUS_STARTING;
+            }
+            case Started -> {
+                return RuntimeStatus.RUNTIME_STATUS_STARTED;
+            }
+            default -> {
+                return RuntimeStatus.RUNTIME_STATUS_STOPPED;
+            }
+        }
+    }
+
+    @Override
+    public void getStatus(HealthProbeRequest request, StreamObserver<HealthProbeReply> responseObserver) {
+        ServiceTarget currentTarget = this.target;
+
+        if (currentTarget != null
+                && currentTarget.getId() != null
+                && !currentTarget.getId().equals(request.getId())) {
+            LOG.error(
+                    "Requested capability ID ({}) doesn't match existing one {}",
+                    request.getId(),
+                    currentTarget.getId());
+            responseObserver.onError(Status.INVALID_ARGUMENT
+                    .withDescription("Invalid request id " + request.getId())
+                    .asRuntimeException());
+        } else {
+            RuntimeStatus status = mapStatus(camelContext.getStatus());
+            responseObserver.onNext(
+                    HealthProbeReply.newBuilder().setStatus(status).build());
+            responseObserver.onCompleted();
+        }
+    }
+}

--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/test/java/ai/wanaku/capability/camel/DeferredHealthProbeIT.java
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/test/java/ai/wanaku/capability/camel/DeferredHealthProbeIT.java
@@ -1,0 +1,225 @@
+package ai.wanaku.capability.camel;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.camel.CamelContext;
+import org.apache.camel.ServiceStatus;
+import org.apache.camel.impl.DefaultCamelContext;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
+import ai.wanaku.core.exchange.v1.HealthProbeReply;
+import ai.wanaku.core.exchange.v1.HealthProbeRequest;
+import ai.wanaku.core.exchange.v1.RuntimeStatus;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DeferredHealthProbeIT {
+
+    private static CamelContext camelContext;
+
+    /**
+     * A minimal StreamObserver implementation that captures the response, error,
+     * and completion state for test assertions.
+     */
+    private static class TestStreamObserver<T> implements StreamObserver<T> {
+        private final List<T> values = new ArrayList<>();
+        private Throwable error;
+        private boolean completed;
+
+        @Override
+        public void onNext(T value) {
+            values.add(value);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            this.error = t;
+        }
+
+        @Override
+        public void onCompleted() {
+            this.completed = true;
+        }
+
+        T getSingleValue() {
+            assertEquals(1, values.size(), "Expected exactly one response value");
+            return values.get(0);
+        }
+
+        Throwable getError() {
+            return error;
+        }
+
+        boolean isCompleted() {
+            return completed;
+        }
+    }
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        camelContext = new DefaultCamelContext();
+        camelContext.start();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (camelContext != null) {
+            camelContext.stop();
+        }
+    }
+
+    // --- mapStatus tests ---
+
+    @Test
+    void mapStatusInitializingReturnsStarting() {
+        DeferredHealthProbe probe = new DeferredHealthProbe(camelContext);
+        assertEquals(RuntimeStatus.RUNTIME_STATUS_STARTING, probe.mapStatus(ServiceStatus.Initializing));
+    }
+
+    @Test
+    void mapStatusInitializedReturnsStarting() {
+        DeferredHealthProbe probe = new DeferredHealthProbe(camelContext);
+        assertEquals(RuntimeStatus.RUNTIME_STATUS_STARTING, probe.mapStatus(ServiceStatus.Initialized));
+    }
+
+    @Test
+    void mapStatusStartingReturnsStarting() {
+        DeferredHealthProbe probe = new DeferredHealthProbe(camelContext);
+        assertEquals(RuntimeStatus.RUNTIME_STATUS_STARTING, probe.mapStatus(ServiceStatus.Starting));
+    }
+
+    @Test
+    void mapStatusStartedReturnsStarted() {
+        DeferredHealthProbe probe = new DeferredHealthProbe(camelContext);
+        assertEquals(RuntimeStatus.RUNTIME_STATUS_STARTED, probe.mapStatus(ServiceStatus.Started));
+    }
+
+    @Test
+    void mapStatusStoppingReturnsStopped() {
+        DeferredHealthProbe probe = new DeferredHealthProbe(camelContext);
+        assertEquals(RuntimeStatus.RUNTIME_STATUS_STOPPED, probe.mapStatus(ServiceStatus.Stopping));
+    }
+
+    @Test
+    void mapStatusStoppedReturnsStopped() {
+        DeferredHealthProbe probe = new DeferredHealthProbe(camelContext);
+        assertEquals(RuntimeStatus.RUNTIME_STATUS_STOPPED, probe.mapStatus(ServiceStatus.Stopped));
+    }
+
+    @Test
+    void mapStatusSuspendingReturnsStopped() {
+        DeferredHealthProbe probe = new DeferredHealthProbe(camelContext);
+        assertEquals(RuntimeStatus.RUNTIME_STATUS_STOPPED, probe.mapStatus(ServiceStatus.Suspending));
+    }
+
+    @Test
+    void mapStatusSuspendedReturnsStopped() {
+        DeferredHealthProbe probe = new DeferredHealthProbe(camelContext);
+        assertEquals(RuntimeStatus.RUNTIME_STATUS_STOPPED, probe.mapStatus(ServiceStatus.Suspended));
+    }
+
+    // --- getStatus tests: no target set ---
+
+    @Test
+    void getStatusBeforeTargetSetReturnsStartedStatus() {
+        DeferredHealthProbe probe = new DeferredHealthProbe(camelContext);
+        HealthProbeRequest request = HealthProbeRequest.newBuilder().build();
+        TestStreamObserver<HealthProbeReply> observer = new TestStreamObserver<>();
+
+        probe.getStatus(request, observer);
+
+        assertNull(observer.getError(), "Should not produce an error when no target is set");
+        assertTrue(observer.isCompleted(), "Response stream should be completed");
+        HealthProbeReply reply = observer.getSingleValue();
+        assertEquals(RuntimeStatus.RUNTIME_STATUS_STARTED, reply.getStatus());
+    }
+
+    @Test
+    void getStatusBeforeTargetSetWithArbitraryIdStillSucceeds() {
+        DeferredHealthProbe probe = new DeferredHealthProbe(camelContext);
+        HealthProbeRequest request =
+                HealthProbeRequest.newBuilder().setId("some-arbitrary-id").build();
+        TestStreamObserver<HealthProbeReply> observer = new TestStreamObserver<>();
+
+        probe.getStatus(request, observer);
+
+        assertNull(observer.getError(), "Should not validate ID when no target is set");
+        assertTrue(observer.isCompleted(), "Response stream should be completed");
+        HealthProbeReply reply = observer.getSingleValue();
+        assertEquals(RuntimeStatus.RUNTIME_STATUS_STARTED, reply.getStatus());
+    }
+
+    // --- getStatus tests: target set with matching ID ---
+
+    @Test
+    void getStatusWithMatchingTargetIdReturnsStartedStatus() {
+        DeferredHealthProbe probe = new DeferredHealthProbe(camelContext);
+        ServiceTarget target = new ServiceTarget(
+                "test-capability-123", "test-service", "localhost", 9090, "tool-invoker", null, null, null, null);
+        probe.setTarget(target);
+
+        HealthProbeRequest request =
+                HealthProbeRequest.newBuilder().setId("test-capability-123").build();
+        TestStreamObserver<HealthProbeReply> observer = new TestStreamObserver<>();
+
+        probe.getStatus(request, observer);
+
+        assertNull(observer.getError(), "Should not produce an error for matching ID");
+        assertTrue(observer.isCompleted(), "Response stream should be completed");
+        HealthProbeReply reply = observer.getSingleValue();
+        assertEquals(RuntimeStatus.RUNTIME_STATUS_STARTED, reply.getStatus());
+    }
+
+    // --- getStatus tests: target set with mismatching ID ---
+
+    @Test
+    void getStatusWithMismatchingTargetIdReturnsInvalidArgument() {
+        DeferredHealthProbe probe = new DeferredHealthProbe(camelContext);
+        ServiceTarget target = new ServiceTarget(
+                "expected-id", "test-service", "localhost", 9090, "tool-invoker", null, null, null, null);
+        probe.setTarget(target);
+
+        HealthProbeRequest request =
+                HealthProbeRequest.newBuilder().setId("wrong-id").build();
+        TestStreamObserver<HealthProbeReply> observer = new TestStreamObserver<>();
+
+        probe.getStatus(request, observer);
+
+        assertNotNull(observer.getError(), "Should produce an error for mismatching ID");
+        assertTrue(observer.getError() instanceof StatusRuntimeException, "Error should be a StatusRuntimeException");
+        StatusRuntimeException sre = (StatusRuntimeException) observer.getError();
+        assertEquals(Status.INVALID_ARGUMENT.getCode(), sre.getStatus().getCode());
+        assertTrue(
+                sre.getStatus().getDescription().contains("wrong-id"),
+                "Error description should contain the invalid request ID");
+    }
+
+    // --- getStatus edge case: target set with null ID ---
+
+    @Test
+    void getStatusWithTargetHavingNullIdSkipsValidation() {
+        DeferredHealthProbe probe = new DeferredHealthProbe(camelContext);
+        // ServiceTarget with null id -- created via newEmptyTarget
+        ServiceTarget target = ServiceTarget.newEmptyTarget("test-service", "localhost", 9090, "tool-invoker");
+        probe.setTarget(target);
+
+        HealthProbeRequest request =
+                HealthProbeRequest.newBuilder().setId("any-id").build();
+        TestStreamObserver<HealthProbeReply> observer = new TestStreamObserver<>();
+
+        probe.getStatus(request, observer);
+
+        assertNull(observer.getError(), "Should not validate ID when target has null ID");
+        assertTrue(observer.isCompleted(), "Response stream should be completed");
+        HealthProbeReply reply = observer.getSingleValue();
+        assertEquals(RuntimeStatus.RUNTIME_STATUS_STARTED, reply.getStatus());
+    }
+}


### PR DESCRIPTION
## Summary

- Decoupled resource downloads from the registration callback — downloads now happen directly, before the gRPC server starts
- Introduced `DeferredHealthProbe` that responds to health probes before registration completes (no target ID validation needed initially)
- Restructured startup order: download → start CamelContext → start gRPC server → register with router

## Root Cause

The router sends an immediate health check right after a capability registers (`DiscoveryResource.register()` sends an EventBus event). Previously, the capability registered **before** the gRPC server started, so the health probe failed with a connection error. The router then set the health status to `DOWN`, and the periodic sweep skipped it permanently because `ActivityRecord.isActive()` returns `false` for `DOWN` status.

## Test plan

- [x] All 25 tests pass (13 new `DeferredHealthProbeIT` + 12 existing)
- [ ] Deploy and verify the capability reports "Up" on the router's capabilities page

## Summary by Sourcery

Start the gRPC server and expose a deferred health probe before capability registration to eliminate a startup race with router health checks.

New Features:
- Introduce a DeferredHealthProbe that serves health status before and after registration, with optional target ID validation.

Bug Fixes:
- Fix a race condition where router health checks could fail because the gRPC server was not yet running when registration completed.

Tests:
- Add DeferredHealthProbe integration tests covering CamelContext status mapping, pre-registration behavior, and ID validation edge cases.