### PR TITLE
Fix #82: use WanakuRegistrationInfo and ExecutorService for registration

### DIFF
--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
@@ -260,7 +260,7 @@ public class CamelToolMain implements Callable<Integer> {
                 .addService(new CamelTool(registrationInfoFuture))
                 .addService(new CamelResource(registrationInfoFuture))
                 .addService(new ProvisionBase(name))
-                .addService(new CamelHealthProbe(registrationInfoFuture, serviceTarget))
+                .addService(new CamelHealthProbe(registrationInfoFuture))
                 .build();
 
         server.start();
@@ -282,8 +282,11 @@ public class CamelToolMain implements Callable<Integer> {
     }
 
     private static void tearDown(
-            WanakuRegistrationInfo info, Throwable ex, CompletableFuture<WanakuRegistrationInfo> registrationInfoFuture,
-            Server server, ExecutorService executor) {
+            WanakuRegistrationInfo info,
+            Throwable ex,
+            CompletableFuture<WanakuRegistrationInfo> registrationInfoFuture,
+            Server server,
+            ExecutorService executor) {
         if (ex != null) {
             LOG.error("Registration failed, shutting down", ex);
             registrationInfoFuture.completeExceptionally(ex);
@@ -295,7 +298,9 @@ public class CamelToolMain implements Callable<Integer> {
     }
 
     private WanakuRegistrationInfo newWanakuRegistrationInfo(
-            RegistrationResult result, ServiceConfig serviceConfig, WanakuCamelManager.RouteLoadingFailurePolicy policy) {
+            RegistrationResult result,
+            ServiceConfig serviceConfig,
+            WanakuCamelManager.RouteLoadingFailurePolicy policy) {
         if (result == null) {
             throw new RuntimeException("Failed to download external resources");
         }
@@ -304,7 +309,7 @@ public class CamelToolMain implements Callable<Integer> {
         WanakuCamelManager camelManager =
                 new WanakuCamelManager(result.downloadedResources(), repositoriesList, policy);
 
-        return new WanakuRegistrationInfo(camelManager.getCamelContext(), mcpSpec);
+        return new WanakuRegistrationInfo(camelManager.getCamelContext(), mcpSpec, result.serviceTarget());
     }
 
     private RegistrationResult downloadExternalResources(

--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
@@ -273,31 +273,38 @@ public class CamelToolMain implements Callable<Integer> {
 
         CompletableFuture.supplyAsync(
                         () -> downloadExternalResources(serviceConfig, dataDirPath, serviceTarget), executor)
-                .thenApply(result -> {
-                    if (result == null) {
-                        throw new RuntimeException("Failed to download external resources");
-                    }
-
-                    McpSpec mcpSpec = createMcpSpec(serviceConfig, result.downloadedResources());
-                    WanakuCamelManager camelManager =
-                            new WanakuCamelManager(result.downloadedResources(), repositoriesList, policy);
-
-                    return new WanakuRegistrationInfo(camelManager.getCamelContext(), mcpSpec);
-                })
-                .whenComplete((info, ex) -> {
-                    if (ex != null) {
-                        LOG.error("Registration failed, shutting down", ex);
-                        registrationInfoFuture.completeExceptionally(ex);
-                        server.shutdown();
-                    } else {
-                        registrationInfoFuture.complete(info);
-                    }
-                    executor.shutdown();
-                });
+                .thenApply(result -> newWanakuRegistrationInfo(result, serviceConfig, policy))
+                .whenComplete((info, ex) -> tearDown(info, ex, registrationInfoFuture, server, executor));
 
         server.awaitTermination();
 
         return 0;
+    }
+
+    private static void tearDown(
+            WanakuRegistrationInfo info, Throwable ex, CompletableFuture<WanakuRegistrationInfo> registrationInfoFuture,
+            Server server, ExecutorService executor) {
+        if (ex != null) {
+            LOG.error("Registration failed, shutting down", ex);
+            registrationInfoFuture.completeExceptionally(ex);
+            server.shutdown();
+        } else {
+            registrationInfoFuture.complete(info);
+        }
+        executor.shutdown();
+    }
+
+    private WanakuRegistrationInfo newWanakuRegistrationInfo(
+            RegistrationResult result, ServiceConfig serviceConfig, WanakuCamelManager.RouteLoadingFailurePolicy policy) {
+        if (result == null) {
+            throw new RuntimeException("Failed to download external resources");
+        }
+
+        McpSpec mcpSpec = createMcpSpec(serviceConfig, result.downloadedResources());
+        WanakuCamelManager camelManager =
+                new WanakuCamelManager(result.downloadedResources(), repositoriesList, policy);
+
+        return new WanakuRegistrationInfo(camelManager.getCamelContext(), mcpSpec);
     }
 
     private RegistrationResult downloadExternalResources(

--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
@@ -8,7 +8,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
-import org.apache.camel.CamelContext;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.grpc.Grpc;
@@ -39,6 +40,7 @@ import ai.wanaku.capabilities.sdk.runtime.camel.grpc.CamelHealthProbe;
 import ai.wanaku.capabilities.sdk.runtime.camel.grpc.CamelResource;
 import ai.wanaku.capabilities.sdk.runtime.camel.grpc.CamelTool;
 import ai.wanaku.capabilities.sdk.runtime.camel.grpc.ProvisionBase;
+import ai.wanaku.capabilities.sdk.runtime.camel.grpc.WanakuRegistrationInfo;
 import ai.wanaku.capabilities.sdk.runtime.camel.init.Initializer;
 import ai.wanaku.capabilities.sdk.runtime.camel.init.InitializerFactory;
 import ai.wanaku.capabilities.sdk.runtime.camel.model.McpSpec;
@@ -250,16 +252,15 @@ public class CamelToolMain implements Callable<Integer> {
                 .build();
 
         final ServiceTarget serviceTarget = newServiceTargetTarget();
-        final McpSpec mcpSpec = new McpSpec();
-        final CompletableFuture<CamelContext> contextFuture = new CompletableFuture<>();
+        final CompletableFuture<WanakuRegistrationInfo> registrationInfoFuture = new CompletableFuture<>();
 
         final ServerBuilder<?> serverBuilder =
                 Grpc.newServerBuilderForPort(grpcPort, InsecureServerCredentials.create());
         final Server server = serverBuilder
-                .addService(new CamelTool(contextFuture, mcpSpec))
-                .addService(new CamelResource(contextFuture, mcpSpec))
+                .addService(new CamelTool(registrationInfoFuture))
+                .addService(new CamelResource(registrationInfoFuture))
                 .addService(new ProvisionBase(name))
-                .addService(new CamelHealthProbe(contextFuture, serviceTarget))
+                .addService(new CamelHealthProbe(registrationInfoFuture, serviceTarget))
                 .build();
 
         server.start();
@@ -268,37 +269,31 @@ public class CamelToolMain implements Callable<Integer> {
                 ? WanakuCamelManager.RouteLoadingFailurePolicy.FAIL_FAST
                 : WanakuCamelManager.RouteLoadingFailurePolicy.LOG_AND_CONTINUE;
 
-        Thread registrationThread = new Thread(
-                () -> {
-                    try {
-                        RegistrationResult result =
-                                downloadExternalResources(serviceConfig, dataDirPath, serviceTarget);
-                        if (result == null) {
-                            contextFuture.completeExceptionally(
-                                    new RuntimeException("Failed to download external resources"));
-                            return;
-                        }
+        ExecutorService executor = Executors.newSingleThreadExecutor(r -> new Thread(r, "registration"));
 
-                        McpSpec loaded = createMcpSpec(serviceConfig, result.downloadedResources());
-                        mcpSpec.setMcp(loaded.getMcp());
-
-                        WanakuCamelManager camelManager =
-                                new WanakuCamelManager(result.downloadedResources(), repositoriesList, policy);
-                        contextFuture.complete(camelManager.getCamelContext());
-                    } catch (Exception e) {
-                        contextFuture.completeExceptionally(e);
+        CompletableFuture.supplyAsync(
+                        () -> downloadExternalResources(serviceConfig, dataDirPath, serviceTarget), executor)
+                .thenApply(result -> {
+                    if (result == null) {
+                        throw new RuntimeException("Failed to download external resources");
                     }
-                },
-                "registration");
 
-        registrationThread.start();
+                    McpSpec mcpSpec = createMcpSpec(serviceConfig, result.downloadedResources());
+                    WanakuCamelManager camelManager =
+                            new WanakuCamelManager(result.downloadedResources(), repositoriesList, policy);
 
-        contextFuture.whenComplete((ctx, ex) -> {
-            if (ex != null) {
-                LOG.error("Registration failed, shutting down", ex);
-                server.shutdown();
-            }
-        });
+                    return new WanakuRegistrationInfo(camelManager.getCamelContext(), mcpSpec);
+                })
+                .whenComplete((info, ex) -> {
+                    if (ex != null) {
+                        LOG.error("Registration failed, shutting down", ex);
+                        registrationInfoFuture.completeExceptionally(ex);
+                        server.shutdown();
+                    } else {
+                        registrationInfoFuture.complete(info);
+                    }
+                    executor.shutdown();
+                });
 
         server.awaitTermination();
 


### PR DESCRIPTION
## Summary

- Use `CompletableFuture<WanakuRegistrationInfo>` instead of mutable `McpSpec` + `CompletableFuture<CamelContext>`
- Replace raw `Thread` with `ExecutorService` and `CompletableFuture.supplyAsync()` pipeline
- gRPC server starts immediately; registration, downloads, and CamelContext creation run in a background thread
- Depends on SDK PR: wanaku-ai/wanaku-capabilities-java-sdk#124

## Test plan

- [x] All 12 tests pass (`mvn verify`)
- [x] Manual test against running Wanaku instance (gRPC starts, registration succeeds, error handling shuts down server on failure)

## Summary by Sourcery

Refactor Camel tool startup to drive gRPC services from a WanakuRegistrationInfo future and run registration work asynchronously via an ExecutorService.

Enhancements:
- Drive CamelTool, CamelResource, and CamelHealthProbe from a CompletableFuture<WanakuRegistrationInfo> instead of a mutable McpSpec and CamelContext future.
- Replace the manual registration Thread with an ExecutorService and CompletableFuture pipeline that downloads resources, builds the MCP spec, and initializes the Camel context.
- Centralize registration completion and failure handling in a teardown helper that completes the registration future, logs errors, shuts down the server on failure, and terminates the executor.