### PR TITLE
ci camel add forage support

### DIFF
--- a/camel-integration-capability-runtimes/camel-integration-capability-main/pom.xml
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/pom.xml
@@ -32,6 +32,12 @@
             <version>${wanaku-capabilities-sdk.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>ai.wanaku.sdk</groupId>
+            <artifactId>capabilities-maven-downloader</artifactId>
+            <version>${wanaku-capabilities-sdk.version}</version>
+        </dependency>
+
         <!-- CLI -->
         <dependency>
             <groupId>org.apache.camel</groupId>

--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/WanakuCamelManager.java
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/WanakuCamelManager.java
@@ -48,9 +48,8 @@ public class WanakuCamelManager {
                     downloadedResources.get(ResourceType.DEPENDENCY_REF).toString();
             try {
                 final List<String> depLines = Files.readAllLines(Path.of(dependenciesPath));
-                final Optional<String> firstDepLine =
-                        depLines.stream().filter(l -> !l.startsWith("#")).findFirst();
-                this.dependenciesList = firstDepLine.orElse(null);
+                this.dependenciesList =
+                        depLines.stream().filter(l -> !l.startsWith("#")).collect(Collectors.joining(","));
 
             } catch (IOException e) {
                 throw new RuntimeException(e);

--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/WanakuCamelManager.java
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/WanakuCamelManager.java
@@ -3,14 +3,17 @@ package ai.wanaku.capability.camel;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
+import java.util.stream.Collectors;
 import org.apache.camel.CamelContext;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import ai.wanaku.capabilities.sdk.maven.GAV;
+import ai.wanaku.capabilities.sdk.maven.WanakuMavenDownloader;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceType;
 import ai.wanaku.capabilities.sdk.runtime.camel.exceptions.RouteLoadingException;
 import ai.wanaku.capabilities.sdk.runtime.camel.util.WanakuRoutesLoader;
@@ -25,9 +28,8 @@ public class WanakuCamelManager {
 
     private final CamelContext context;
     private final String routesPath;
-    private final String dependenciesList;
-    private final String repositoriesList;
     private final RouteLoadingFailurePolicy routeLoadingFailurePolicy;
+    private List<GAV> gavs = new ArrayList<>();
 
     public WanakuCamelManager(Map<ResourceType, Path> downloadedResources, String repositoriesList) {
         this(downloadedResources, repositoriesList, RouteLoadingFailurePolicy.FAIL_FAST);
@@ -37,10 +39,8 @@ public class WanakuCamelManager {
             Map<ResourceType, Path> downloadedResources,
             String repositoriesList,
             RouteLoadingFailurePolicy routeLoadingFailurePolicy) {
-        this.repositoriesList = repositoriesList;
         this.routeLoadingFailurePolicy =
                 Objects.requireNonNull(routeLoadingFailurePolicy, "RouteLoadingFailurePolicy must not be null");
-        context = new DefaultCamelContext();
 
         this.routesPath = downloadedResources.get(ResourceType.ROUTES_REF).toString();
         if (downloadedResources.containsKey(ResourceType.DEPENDENCY_REF)) {
@@ -48,21 +48,26 @@ public class WanakuCamelManager {
                     downloadedResources.get(ResourceType.DEPENDENCY_REF).toString();
             try {
                 final List<String> depLines = Files.readAllLines(Path.of(dependenciesPath));
-                this.dependenciesList =
-                        depLines.stream().filter(l -> !l.startsWith("#")).collect(Collectors.joining(","));
+                this.gavs = depLines.stream()
+                        .filter(l -> !l.startsWith("#"))
+                        .map(GAV::parse)
+                        .collect(Collectors.toList());
 
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-        } else {
-            this.dependenciesList = null;
         }
 
+        WanakuMavenDownloader mavenDownloader = new WanakuMavenDownloader(WanakuCamelManager.class.getClassLoader());
+        mavenDownloader.download(gavs);
+
+        context = new DefaultCamelContext();
+        context.setApplicationContextClassLoader(mavenDownloader.getClassLoader());
         loadRoutes();
     }
 
     private void loadRoutes() {
-        WanakuRoutesLoader routesLoader = new WanakuRoutesLoader(dependenciesList, repositoriesList);
+        WanakuRoutesLoader routesLoader = new WanakuRoutesLoader();
 
         String routeFileUrl = Path.of(routesPath).toUri().toString();
 
@@ -77,6 +82,7 @@ public class WanakuCamelManager {
                         e.getMessage());
             }
         }
+
         context.start();
     }
 

--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/resources/log4j2.properties
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/resources/log4j2.properties
@@ -20,17 +20,17 @@
 appender.console.type = Console
 appender.console.name = console
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %style{%d{DEFAULT}}{dim} [%highlight{%-5p}] %m%n
+appender.console.layout.pattern = %style{%d{DEFAULT}}{dim} [%highlight{%-5p}] %c %m%n
 
 logger.camel.name = org.apache.camel
 logger.camel.level = INFO
 logger.camel.additivity = false
 logger.camel.appenderRef.file.ref = console
 
-logger.kafka.name = org.apache.kafka
-logger.kafka.level = INFO
-logger.kafka.additivity = false
-logger.kafka.appenderRef.file.ref = console
+logger.forage.name = io.kaoto.forage
+logger.forage.level = DEBUG
+logger.forage.additivity = false
+logger.forage.appenderRef.file.ref = console
 
 logger.wanaku-console.name = ai.wanaku
 logger.wanaku-console.level = DEBUG

--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/test/resources/test-routes-dependencies.txt
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/test/resources/test-routes-dependencies.txt
@@ -1,1 +1,6 @@
 com.github.curious-odd-man:rgxgen:1.4
+org.apache.camel:camel-jsonpath:4.18.2
+org.apache.camel:camel-jq:4.18.2
+org.apache.camel:camel-groovy:4.18.2
+org.apache.camel:camel-kafka:4.18.2
+org.apache.camel:camel-http:4.18.2

--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/test/resources/test-routes.camel.yaml
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/test/resources/test-routes.camel.yaml
@@ -3,7 +3,7 @@
     from:
       uri: direct:test-component
       steps:
-        - to: https://api.example.com/test
+        - to: seda:anotherComponent
 
 - route:
     id: test-dataformat-resolver

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <camel.version>4.18.1</camel.version>
+        <camel.version>4.18.2</camel.version>
         <slf4j.version>2.0.17</slf4j.version>
         <log4j.version>2.25.4</log4j.version>
         <picocli.version>4.7.7</picocli.version>


### PR DESCRIPTION
- **Fix ignoring subsequent lines on the dependencies file**
- **Preliminary support for Forage**

## Summary by Sourcery

Update Camel integration runtime to load all declared dependencies via a Maven downloader and initialize the Camel context with the downloaded classloader.

New Features:
- Support loading multiple dependencies from the dependencies file instead of only the first non-comment line.
- Integrate a Maven-based dependency downloader into the Camel runtime startup.
- Introduce dedicated logging configuration for Forage components.

Enhancements:
- Bump Apache Camel dependency to version 4.18.2.