### PR TITLE
chore: archive JUnit test results as CI artifacts

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -43,6 +43,17 @@ jobs:
         cd ${{ github.workspace }}
     - name: Build with Maven
       run: mvn -B clean package --file pom.xml
+    - name: Generate Test Reports
+      if: always()
+      run: mvn -B --no-transfer-progress surefire-report:report-only surefire-report:failsafe-report-only -Daggregate=true
+    - name: Upload Test Reports
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-reports-${{ matrix.os }}
+        path: 'target/reports/'
+        retention-days: 14
+        if-no-files-found: ignore
     - name: Set arch
       id: arch
       run: echo "arch=$(uname -m)" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -47,3 +47,14 @@ jobs:
         cd ${{ github.workspace }}
     - name: Build with Maven
       run: mvn -B install --file pom.xml
+    - name: Generate Test Reports
+      if: always()
+      run: mvn -B --no-transfer-progress surefire-report:report-only surefire-report:failsafe-report-only -Daggregate=true
+    - name: Upload Test Reports
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-reports-${{ matrix.os }}
+        path: 'target/reports/'
+        retention-days: 14
+        if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- Add JUnit test report generation and artifact upload to both `main-build.yml` and `pr-builds.yml` workflows
- Uses aggregated surefire/failsafe reports uploaded via `actions/upload-artifact@v4` with 14-day retention
- Mirrors the approach from wanaku-ai/wanaku#1196

## Test plan
- [ ] Verify main build workflow archives test reports after a push to main
- [ ] Verify PR build workflow archives test reports per OS matrix entry
- [ ] Confirm reports are downloadable from the Actions artifacts tab

## Summary by Sourcery

CI:
- Add Maven Surefire/Failsafe report generation to main and PR build workflows and always upload aggregated reports as GitHub Actions artifacts with 14-day retention.