### PR TITLE
chore: add service catalog guide, troubleshooting, CLI reference, and rules schema docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,4 +26,11 @@ Java 21: Follow standard conventions
 - 001-multi-module-split: Added Java 21 + Apache Camel 4.18.2, Wanaku SDK 0.1.1, picocli 4.7.7, gRPC
 
 <!-- MANUAL ADDITIONS START -->
+
+## Documentation
+
+- The primary user-facing documentation is `docs/usage.md` — this is the file published to the documentation website.
+- When adding new documentation files, always link them from `docs/usage.md` (in the "Related Guides" section), not just from `README.md`.
+- Changelogs are handled automatically by jreleaser — do not create or maintain a manual CHANGELOG.md.
+
 <!-- MANUAL ADDITIONS END -->

--- a/README.md
+++ b/README.md
@@ -155,8 +155,12 @@ The guides below cover development and unreleased features. They may describe be
 
 - **[Usage Guide](docs/usage.md)** - Standalone application configuration
 - **[Plugin Guide](docs/plugin-usage.md)** - Embedding in Camel applications
+- **[Service Catalog Guide](docs/service-catalog-guide.md)** - Creating and publishing service catalogs
+- **[CLI Reference](docs/cli-reference.md)** - Complete command-line parameter reference
+- **[Rules Schema](docs/rules-schema.md)** - Route exposure rules YAML reference
 - **[Authentication](docs/authentication.md)** - OAuth2/OIDC configuration
 - **[Operations](docs/operations.md)** - Production deployment and monitoring
+- **[Troubleshooting](docs/troubleshooting.md)** - Common issues and solutions
 - **[Building](docs/building.md)** - Build instructions and development setup
 - **[Migration Guide](docs/migration-guide.md)** - Upgrading between versions
 - **[Examples](examples/)** - Working example routes and configurations

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,420 @@
+# CLI Reference
+
+Complete parameter reference for the Camel Integration Capability standalone application. The service uses [picocli](https://picocli.info/) for command-line parsing.
+
+## Parameter Overview
+
+Parameters are grouped by function: registration, authentication, route configuration, and server settings.
+
+## Registration Parameters
+
+Control how the service registers with the Wanaku MCP Router.
+
+| Parameter | Environment Variable | Required | Default | Description |
+|-----------|---------------------|----------|---------|-------------|
+| `--registration-url` | `REGISTRATION_URL` | Yes | - | URL of the Wanaku discovery service (e.g., `http://wanaku-router:8080`) |
+| `--registration-announce-address` | `REGISTRATION_ANNOUNCE_ADDRESS` | Yes | `auto` | Address the router uses to call back to this service. In Kubernetes, use the service DNS name (e.g., `camel-capability.default.svc.cluster.local`). For local development, use `localhost`. |
+| `--name` | `SERVICE_NAME` | No | `camel` | Service name for registration. Appears in Wanaku's service registry. Must be unique per capability instance. |
+| `--initial-delay` | - | No | `5` | Initial delay before first registration attempt (seconds). Gives the gRPC server time to start. |
+| `--period` | - | No | `5` | Period between registration attempts (seconds). Used during initial registration retry loop. |
+| `--retries` | - | No | `12` | Maximum number of registration retries. After this, the service fails to start. Also applies to resource download retries. |
+| `--wait-seconds` | - | No | `5` | Wait time between retries (seconds). Used for registration and resource downloads. |
+
+### Registration Flow
+
+1. Service starts gRPC server on `--grpc-port`
+2. Waits `--initial-delay` seconds
+3. Attempts registration with Wanaku at `--registration-url`
+4. If registration fails, retries every `--period` seconds, up to `--retries` attempts
+5. On success, begins downloading resources (routes, rules, dependencies)
+6. After resources are loaded, marks itself as ready
+
+**Example**:
+
+```bash
+--registration-url http://wanaku-router:8080 \
+--registration-announce-address my-service.example.com \
+--name employee-integration \
+--retries 20 \
+--wait-seconds 10
+```
+
+This configuration:
+- Registers with the router at `http://wanaku-router:8080`
+- Tells the router to call back at `my-service.example.com:9190`
+- Identifies itself as `employee-integration`
+- Retries registration up to 20 times, waiting 10 seconds between attempts
+
+## Authentication Parameters
+
+OAuth2/OIDC credentials for authenticating with Wanaku services.
+
+| Parameter | Environment Variable | Required | Default | Description |
+|-----------|---------------------|----------|---------|-------------|
+| `--client-id` | `CLIENT_ID` | Yes | - | OAuth2 client ID. Must match a client configured in your OAuth2 provider (e.g., Keycloak). |
+| `--client-secret` | `CLIENT_SECRET` | No | - | OAuth2 client secret. Omit if Wanaku is running without authentication (local development). |
+| `--token-endpoint` | `TOKEN_ENDPOINT` | No | Auto-detected | OAuth2/OIDC token endpoint base URL. If not specified, derived from `--registration-url`. For Keycloak, **include the realm path**: `http://keycloak:8543/realms/my-realm/`. The service appends `/protocol/openid-connect/token`. |
+
+### Auto-Detection of Token Endpoint
+
+If `--token-endpoint` is omitted, the service derives it from `--registration-url`:
+
+```
+--registration-url http://wanaku-router:8080
+→ token endpoint: http://wanaku-router:8080/protocol/openid-connect/token
+```
+
+This works if Wanaku and the OAuth2 provider share the same base URL. For separate OAuth2 providers (e.g., external Keycloak), specify `--token-endpoint` explicitly.
+
+### Keycloak Configuration
+
+For Keycloak, the token endpoint format is:
+
+```
+http://<keycloak-host>:<port>/realms/<realm-name>/protocol/openid-connect/token
+```
+
+The service appends `/protocol/openid-connect/token`, so provide:
+
+```bash
+--token-endpoint http://keycloak:8543/realms/wanaku/
+```
+
+**Wrong**:
+```bash
+--token-endpoint http://keycloak:8543/
+```
+
+Without the realm path, token acquisition will fail with 404.
+
+### Example: Full Authentication Configuration
+
+```bash
+--client-id wanaku-camel-service \
+--client-secret aBqsU3EzUPCHumf9sTK5sanxXkB0yFtv \
+--token-endpoint http://keycloak:8543/realms/production/
+```
+
+### Example: No Authentication (Development)
+
+```bash
+--client-id camel-dev
+```
+
+Omit `--client-secret` when Wanaku is running without authentication. The service will skip OAuth2 token acquisition.
+
+## Route Configuration Parameters
+
+Control how the service loads routes, rules, and dependencies.
+
+### Service Catalog Mode (Recommended)
+
+| Parameter | Environment Variable | Required | Default | Description |
+|-----------|---------------------|----------|---------|-------------|
+| `--service-catalog` | `SERVICE_CATALOG` | No | - | Name of the service catalog to use. Must match `catalog.name` in the catalog's `index.properties`. Mutually exclusive with `--routes-ref`, `--rules-ref`, and `--dependencies`. |
+| `--service-catalog-system` | `SERVICE_CATALOG_SYSTEM` | Yes (if using catalog) | - | System name within the catalog. Must be listed in `catalog.services` in the catalog's `index.properties`. |
+
+**Example**:
+
+```bash
+--service-catalog employee-system-v2 \
+--service-catalog-system employee-system
+```
+
+The service will:
+1. Download `employee-system-v2.zip` from Wanaku's DataStore after registration
+2. Extract the catalog's `index.properties`
+3. Locate the `employee-system` resources within the catalog
+4. Load routes, rules, and dependencies from the extracted files
+
+See [Service Catalog Guide](service-catalog-guide.md) for details on creating and publishing catalogs.
+
+### Individual File References Mode
+
+| Parameter | Environment Variable | Required | Default | Description |
+|-----------|---------------------|----------|---------|-------------|
+| `--routes-ref` | `ROUTES_REF` | Yes (if not using catalog) | - | Reference to the Apache Camel routes YAML file. Supports `datastore://` and `file://` schemes. |
+| `--rules-ref` | `RULES_REF` | No | - | Reference to the route exposure rules YAML file. Supports `datastore://` and `file://` schemes. If omitted, no routes are exposed as MCP tools/resources. |
+| `--dependencies` | `DEPENDENCIES` | No | - | Reference to a text file containing a comma-separated or newline-separated list of Maven dependencies (GAV format). Supports `datastore://` and `file://` schemes. |
+| `--repositories` | `REPOSITORIES` | No | Maven Central | Comma-separated list of additional Maven repository URLs to use for downloading dependencies. |
+
+**Supported URI Schemes**:
+
+- **`datastore://`**: Downloads the file from Wanaku's DataStore after registration. Example: `datastore://routes.camel.yaml`
+- **`file://`**: Loads the file from the local filesystem. Must be an absolute path. Example: `file:///data/routes.camel.yaml`
+
+**Example: DataStore References**:
+
+```bash
+--routes-ref datastore://employee-routes.camel.yaml \
+--rules-ref datastore://employee-rules.yaml \
+--dependencies datastore://employee-deps.txt
+```
+
+**Example: Local File References**:
+
+```bash
+--routes-ref file:///tmp/routes.camel.yaml \
+--rules-ref file:///tmp/rules.yaml \
+--dependencies file:///tmp/deps.txt
+```
+
+**Example: Custom Maven Repositories**:
+
+```bash
+--dependencies datastore://deps.txt \
+--repositories https://my-private-repo.com/maven,https://repo.company.com/nexus
+```
+
+Dependencies will be downloaded from these repositories in addition to Maven Central.
+
+### Mutual Exclusivity
+
+`--service-catalog` is mutually exclusive with `--routes-ref`, `--rules-ref`, and `--dependencies`. You must choose one mode:
+
+**Catalog mode**:
+```bash
+--service-catalog my-catalog \
+--service-catalog-system my-system
+```
+
+**Individual files mode**:
+```bash
+--routes-ref datastore://routes.camel.yaml \
+--rules-ref datastore://rules.yaml
+```
+
+**Invalid (mixing modes)**:
+```bash
+--service-catalog my-catalog \
+--service-catalog-system my-system \
+--routes-ref datastore://routes.camel.yaml  # ERROR
+```
+
+The service will reject this configuration at startup.
+
+### Git Initialization
+
+| Parameter | Environment Variable | Required | Default | Description |
+|-----------|---------------------|----------|---------|-------------|
+| `--init-from` | `INIT_FROM` | No | - | Git repository URL to clone during initialization (before registration). Supports SSH (`git@github.com:org/repo.git`) and HTTPS (`https://github.com/org/repo.git`) formats. Cloned repository is placed in a subdirectory of `--data-dir`. |
+
+**Example**:
+
+```bash
+--init-from git@github.com:wanaku-ai/wanaku-recipes.git \
+--routes-ref file:///tmp/cloned-repo/routes/employee.camel.yaml \
+--rules-ref file:///tmp/cloned-repo/rules/employee.yaml
+```
+
+The repository is cloned to `/tmp/cloned-repo/` (assuming `--data-dir=/tmp`), then files are loaded using `file://` references.
+
+**Note**: Git initialization happens before registration. If the clone fails (e.g., SSH key issues, network problems), the service fails to start.
+
+## Server Configuration Parameters
+
+Control the gRPC server and data storage.
+
+| Parameter | Environment Variable | Required | Default | Description |
+|-----------|---------------------|----------|---------|-------------|
+| `--grpc-port` | `GRPC_PORT` | No | `9190` | Port the gRPC server listens on. Must match the port Wanaku uses to call back to the service. In Kubernetes, ensure this matches the Service's `targetPort`. |
+| `--data-dir` | `DATA_DIR` | No | `/tmp` | Directory where downloaded files (routes, rules, dependencies) are saved. In Kubernetes, mount a volume here if `/tmp` is read-only. In Docker, the default is `/data`. |
+| `--fail-fast` | - | No | `false` | If `true`, the service fails immediately if any route fails to load. If `false`, route loading errors are logged and the service continues with successfully loaded routes. |
+| `--no-wait` | - | No | `false` | **Deprecated**. Previously controlled whether the service waited for resources to be available. Now ignored. |
+
+**Example: Custom gRPC Port and Data Directory**:
+
+```bash
+--grpc-port 9191 \
+--data-dir /var/camel-data
+```
+
+**Example: Fail-Fast for Development**:
+
+```bash
+--fail-fast=true
+```
+
+With this setting, the service shuts down on the first route loading error. Useful for catching syntax errors or missing dependencies early.
+
+## Help and Version
+
+| Parameter | Description |
+|-----------|-------------|
+| `-h`, `--help` | Display help message and exit. Shows all available parameters with descriptions. |
+
+**Example**:
+
+```bash
+java -jar camel-integration-capability-main-*-jar-with-dependencies.jar --help
+```
+
+## Complete Examples
+
+### Minimal Configuration (Service Catalog)
+
+```bash
+java -jar camel-integration-capability-main-0.1.0-jar-with-dependencies.jar \
+  --registration-url http://wanaku-router:8080 \
+  --registration-announce-address my-service.example.com \
+  --service-catalog employee-system-v2 \
+  --service-catalog-system employee-system \
+  --client-id wanaku-service \
+  --client-secret aBqsU3EzUPCHumf9sTK5sanxXkB0yFtv
+```
+
+### Individual File References with Dependencies
+
+```bash
+java -jar camel-integration-capability-main-0.1.0-jar-with-dependencies.jar \
+  --registration-url http://wanaku-router:8080 \
+  --registration-announce-address my-service.example.com \
+  --routes-ref datastore://employee.camel.yaml \
+  --rules-ref datastore://employee-rules.yaml \
+  --dependencies datastore://employee-deps.txt \
+  --repositories https://my-repo.com/maven \
+  --client-id wanaku-service \
+  --client-secret aBqsU3EzUPCHumf9sTK5sanxXkB0yFtv \
+  --data-dir /data
+```
+
+### Local Development (No Authentication)
+
+```bash
+java -jar camel-integration-capability-main-0.1.0-jar-with-dependencies.jar \
+  --registration-url http://localhost:8080 \
+  --registration-announce-address localhost \
+  --routes-ref file:///workspace/routes.camel.yaml \
+  --rules-ref file:///workspace/rules.yaml \
+  --client-id camel-dev
+```
+
+### Git Initialization with File References
+
+```bash
+java -jar camel-integration-capability-main-0.1.0-jar-with-dependencies.jar \
+  --registration-url http://wanaku-router:8080 \
+  --registration-announce-address camel-capability.prod.svc.cluster.local \
+  --init-from git@github.com:my-org/camel-routes.git \
+  --routes-ref file:///tmp/cloned-repo/routes/production.camel.yaml \
+  --rules-ref file:///tmp/cloned-repo/rules/production.yaml \
+  --dependencies file:///tmp/cloned-repo/deps/production.txt \
+  --client-id wanaku-service \
+  --client-secret aBqsU3EzUPCHumf9sTK5sanxXkB0yFtv \
+  --data-dir /tmp
+```
+
+### Custom gRPC Port with Fail-Fast
+
+```bash
+java -jar camel-integration-capability-main-0.1.0-jar-with-dependencies.jar \
+  --registration-url http://wanaku-router:8080 \
+  --registration-announce-address my-service.example.com \
+  --grpc-port 9191 \
+  --fail-fast=true \
+  --service-catalog test-catalog-v1 \
+  --service-catalog-system test-system \
+  --client-id wanaku-service \
+  --client-secret test-secret
+```
+
+### Extended Retry Configuration
+
+```bash
+java -jar camel-integration-capability-main-0.1.0-jar-with-dependencies.jar \
+  --registration-url http://wanaku-router:8080 \
+  --registration-announce-address my-service.example.com \
+  --retries 30 \
+  --wait-seconds 10 \
+  --initial-delay 10 \
+  --period 10 \
+  --service-catalog employee-system-v2 \
+  --service-catalog-system employee-system \
+  --client-id wanaku-service \
+  --client-secret aBqsU3EzUPCHumf9sTK5sanxXkB0yFtv
+```
+
+This gives the service 5 minutes to register (30 retries × 10 seconds), useful in environments where the router or OAuth2 provider takes time to start.
+
+## Environment Variables
+
+All CLI parameters can be set via environment variables. The mapping follows a standard pattern:
+
+**CLI parameter → Environment variable**:
+
+- `--registration-url` → `REGISTRATION_URL`
+- `--client-id` → `CLIENT_ID`
+- `--service-catalog` → `SERVICE_CATALOG`
+- etc.
+
+**Example in Kubernetes**:
+
+```yaml
+env:
+  - name: REGISTRATION_URL
+    value: "http://wanaku-router:8080"
+  - name: REGISTRATION_ANNOUNCE_ADDRESS
+    value: "camel-capability.default.svc.cluster.local"
+  - name: SERVICE_CATALOG
+    value: "employee-system-v2"
+  - name: SERVICE_CATALOG_SYSTEM
+    value: "employee-system"
+  - name: CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: wanaku-credentials
+        key: client-id
+  - name: CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: wanaku-credentials
+        key: client-secret
+```
+
+CLI parameters take precedence over environment variables. If both are set, the CLI value is used.
+
+## Parameter Validation
+
+The service validates parameters at startup. Common validation errors:
+
+**Missing required parameters**:
+
+```
+Missing required option: '--registration-url=<registrationUrl>'
+```
+
+**Mutually exclusive parameters**:
+
+```
+--service-catalog is mutually exclusive with --routes-ref, --rules-ref, and --dependencies
+```
+
+**Service catalog without system**:
+
+```
+--service-catalog-system is required when --service-catalog is used
+```
+
+**Routes reference missing (individual file mode)**:
+
+```
+Either --routes-ref or --service-catalog must be provided
+```
+
+Validation errors cause the service to exit immediately with a non-zero status code.
+
+## Default Values Summary
+
+| Parameter | Default |
+|-----------|---------|
+| `--grpc-port` | `9190` |
+| `--name` | `camel` |
+| `--retries` | `12` |
+| `--wait-seconds` | `5` |
+| `--initial-delay` | `5` |
+| `--period` | `5` |
+| `--data-dir` | `/tmp` (CLI), `/data` (Docker) |
+| `--fail-fast` | `false` |
+| `--registration-announce-address` | `auto` |
+
+All other parameters have no default and must be provided (or are optional).

--- a/docs/rules-schema.md
+++ b/docs/rules-schema.md
@@ -1,0 +1,961 @@
+# Rules Schema Reference
+
+Complete reference for the route exposure rules YAML format. These rules define which Apache Camel routes are exposed to AI agents as MCP tools or resources.
+
+## Overview
+
+The rules file is a YAML document that maps Camel routes to MCP (Model Context Protocol) tools and resources. Tools are invocable operations (e.g., "fetch employee data"). Resources are passive data sources (e.g., "employee performance history").
+
+**File location**: Specified via `--rules-ref` (individual file mode) or included in a service catalog.
+
+**Purpose**: Without a rules file, your Camel routes exist but aren't accessible to AI agents. The rules file is the bridge between Camel's internal routing and Wanaku's external API.
+
+## Top-Level Structure
+
+```yaml
+mcp:
+  tools:
+    - <tool-name>:
+        route:
+          id: "<camel-route-id>"
+        description: "<tool description>"
+        namespace: "<optional-namespace>"
+        properties:
+          - name: <param-name>
+            type: <param-type>
+            description: <param-description>
+            required: <true|false>
+            mapping:
+              type: header
+              name: <camel-header-name>
+  resources:
+    - <resource-name>:
+        route:
+          id: "<camel-route-id>"
+        description: "<resource description>"
+        namespace: "<optional-namespace>"
+```
+
+**Root element**: `mcp`
+
+**Sections**:
+
+- `tools`: List of MCP tools (invocable operations)
+- `resources`: List of MCP resources (passive data sources)
+
+Both are optional. You can define only tools, only resources, or both.
+
+## Tool Definitions
+
+Tools are operations AI agents can invoke. Each invocation executes the mapped Camel route.
+
+### Minimal Tool Definition
+
+```yaml
+mcp:
+  tools:
+    - get-employee-info:
+        route:
+          id: "get-employee-route"
+        description: "Retrieve employee information by ID"
+```
+
+**Fields**:
+
+- **Tool name** (`get-employee-info`): The identifier AI agents use to invoke the tool. Must be unique within this rules file.
+- **`route.id`** (required): ID of the Camel route to execute. Must match a route's `id` in your routes YAML.
+- **`description`** (required): Human-readable description shown to AI agents. Should explain what the tool does and when to use it.
+
+This minimal definition uses **automatic parameter mapping**: all MCP parameters are mapped to Camel headers with a `Wanaku.` prefix.
+
+### Full Tool Definition (Explicit Mapping)
+
+```yaml
+mcp:
+  tools:
+    - initiate-employee-promotion:
+        route:
+          id: "route-3103"
+        description: "Initiate the promotion process for an employee"
+        namespace: hr-operations
+        properties:
+          - name: employee
+            type: string
+            description: The employee ID to promote
+            required: true
+            mapping:
+              type: header
+              name: EMPLOYEE
+          - name: newLevel
+            type: string
+            description: The new organizational level
+            required: false
+            mapping:
+              type: header
+              name: NEW_LEVEL
+```
+
+**Additional fields**:
+
+- **`namespace`** (optional): Namespace for organizing tools in Wanaku's router. Related tools can share a namespace (e.g., `hr-operations`). If omitted, the tool is registered in the default namespace.
+- **`properties`** (optional): List of parameter definitions. When defined, **only these parameters are mapped** (filtered mapping). When omitted, **all parameters are mapped automatically** (automatic mapping).
+
+**Never mix automatic and explicit mapping for the same tool.** Either define `properties` with mappings or omit `properties` entirely.
+
+## Tool Field Reference
+
+### Tool Name
+
+**Format**: YAML key, typically kebab-case.
+
+**Constraints**:
+
+- Must be unique within the rules file
+- Case-sensitive
+- Allowed characters: letters, numbers, hyphens, underscores
+- Should be descriptive and action-oriented
+
+**Good examples**:
+
+- `get-employee-info`
+- `update-inventory-quantity`
+- `send-notification-email`
+
+**Avoid**:
+
+- `tool1`, `tool2` (not descriptive)
+- `Employee Info` (spaces not recommended)
+- `getEmployeeInfo` (camelCase works but kebab-case is more conventional)
+
+### route.id (required)
+
+**Type**: String
+
+**Description**: ID of the Camel route to execute when the tool is invoked.
+
+**Constraints**:
+
+- Must match a route's `id` in your routes YAML exactly (case-sensitive)
+- The route must exist and be successfully loaded
+- One route can be mapped to multiple tools (each with different parameter mappings)
+
+**Example**:
+
+Routes YAML:
+```yaml
+- route:
+    id: get-employee-route
+    from:
+      uri: direct:get-employee-route
+      steps:
+        - log:
+            message: "Fetching employee ${header.Wanaku.employeeId}"
+```
+
+Rules YAML:
+```yaml
+mcp:
+  tools:
+    - get-employee-info:
+        route:
+          id: "get-employee-route"  # Must match
+```
+
+**What happens if the ID doesn't match?**
+
+The tool is registered with Wanaku but invocations will fail with:
+
+```
+Route 'wrong-route-id' not found
+```
+
+### description (required)
+
+**Type**: String
+
+**Description**: Human-readable explanation of what the tool does. Shown to AI agents when they're deciding which tool to use.
+
+**Best practices**:
+
+- Use imperative or descriptive phrasing: "Retrieve employee information" or "Fetches employee data"
+- Mention what the tool returns: "Returns employee name, title, and department"
+- Note any constraints: "Only returns active employees"
+- Keep it concise (1-2 sentences)
+
+**Good examples**:
+
+```yaml
+description: "Retrieve employee information by ID, including name, title, and department"
+```
+
+```yaml
+description: "Initiate the promotion process for an employee. Returns a promotion ticket ID."
+```
+
+**Avoid**:
+
+```yaml
+description: "This tool does stuff with employees"  # Too vague
+```
+
+```yaml
+description: "Calls the backend HR API via HTTP GET using the /employees/{id} endpoint and returns JSON"  # Too technical
+```
+
+AI agents use the description to decide when to invoke the tool. Focus on **what**, not **how**.
+
+### namespace (optional)
+
+**Type**: String
+
+**Description**: Namespace for organizing related tools within Wanaku's router.
+
+**Default**: If omitted, the tool is registered in the default namespace.
+
+**Use cases**:
+
+- Grouping tools by domain: `hr-operations`, `payroll`, `inventory`
+- Separating production and test tools: `prod-tools`, `test-tools`
+- Multi-tenant environments: `tenant-a`, `tenant-b`
+
+**Example**:
+
+```yaml
+mcp:
+  tools:
+    - get-employee-info:
+        route:
+          id: "get-employee-route"
+        description: "Retrieve employee information"
+        namespace: hr-data
+
+    - initiate-promotion:
+        route:
+          id: "promotion-route"
+        description: "Initiate employee promotion"
+        namespace: hr-operations
+```
+
+Both tools are registered but in different namespaces. AI agents can filter or prioritize tools by namespace.
+
+**Constraints**:
+
+- Allowed characters: letters, numbers, hyphens, underscores
+- Case-sensitive
+- No spaces
+
+### properties (optional)
+
+**Type**: List of property definitions
+
+**Description**: Defines the parameters the tool accepts. Each property maps to a Camel header.
+
+**When to define properties**:
+
+- You want explicit control over parameter names (no `Wanaku.` prefix)
+- You need validation (required vs optional parameters)
+- You want to document parameters for AI agents
+- You need to restrict which parameters are passed to the route
+
+**When to omit properties**:
+
+- During development/prototyping
+- You want all parameters passed through automatically
+- You're okay with the `Wanaku.` prefix on all headers
+
+**Important**: Defining `properties` switches to **filtered mapping mode**. Only the defined parameters are mapped. Any additional parameters sent by AI agents are ignored.
+
+## Property Field Reference
+
+Each property in the `properties` list defines one parameter.
+
+### name (required)
+
+**Type**: String
+
+**Description**: The parameter name AI agents use when invoking the tool.
+
+**Example**:
+
+```yaml
+properties:
+  - name: employeeId
+```
+
+AI agents invoke the tool with:
+
+```json
+{
+  "employeeId": "12345"
+}
+```
+
+**Constraints**:
+
+- Case-sensitive
+- Should use camelCase or snake_case
+- No spaces
+
+### type (required)
+
+**Type**: String (parameter type)
+
+**Description**: The parameter's data type. Used for validation and documentation.
+
+**Supported types**:
+
+- `string` — Text values
+- `int` or `integer` — Whole numbers
+- `number` — Floating-point numbers
+- `boolean` — `true` or `false`
+- `object` — Complex JSON objects
+- `array` — Lists
+
+**Example**:
+
+```yaml
+properties:
+  - name: employeeId
+    type: string
+  - name: includeHistory
+    type: boolean
+  - name: limit
+    type: int
+```
+
+**Note**: The capability converts all parameter values to strings when creating Camel headers. Complex types like `object` and `array` are JSON-serialized.
+
+### description (required)
+
+**Type**: String
+
+**Description**: Human-readable description of the parameter. Shown to AI agents.
+
+**Best practices**:
+
+- Explain what the parameter controls
+- Mention valid values or formats if relevant
+- Note constraints (e.g., "Must be a valid employee ID")
+
+**Example**:
+
+```yaml
+properties:
+  - name: employeeId
+    type: string
+    description: The employee ID to retrieve information for (e.g., EMP-12345)
+  - name: includeHistory
+    type: boolean
+    description: Whether to include employment history in the response
+```
+
+### required (required)
+
+**Type**: Boolean (`true` or `false`)
+
+**Description**: Whether the parameter is mandatory.
+
+**Example**:
+
+```yaml
+properties:
+  - name: employeeId
+    type: string
+    description: The employee ID
+    required: true  # AI agents must provide this
+
+  - name: includeHistory
+    type: boolean
+    description: Include employment history
+    required: false  # Optional
+```
+
+**Validation**:
+
+- If `required: true` and the parameter is missing, the invocation fails with an error
+- If `required: false`, the parameter is optional and may be omitted
+
+### mapping (optional)
+
+**Type**: Object with `type` and `name` fields
+
+**Description**: Defines how the parameter is mapped to a Camel header.
+
+**Fields**:
+
+- **`mapping.type`** (required): Mapping type. Currently only `header` is supported.
+- **`mapping.name`** (required): The Camel header name to create.
+
+**Example**:
+
+```yaml
+properties:
+  - name: employee
+    type: string
+    description: The employee ID
+    required: true
+    mapping:
+      type: header
+      name: EMPLOYEE
+```
+
+**Result**:
+
+When invoked with `{"employee": "EMP-789"}`, the Camel route receives:
+
+- Header `EMPLOYEE` with value `"EMP-789"`
+
+**If mapping is omitted**:
+
+The parameter name is used directly as the header name (without the `Wanaku.` prefix, since you're in explicit mapping mode).
+
+**Example without mapping**:
+
+```yaml
+properties:
+  - name: employeeId
+    type: string
+    description: The employee ID
+    required: true
+```
+
+When invoked with `{"employeeId": "12345"}`, the route receives:
+
+- Header `employeeId` with value `"12345"`
+
+**Automatic mapping (no properties defined) vs Explicit mapping (properties with mapping)**:
+
+| Mode | Properties Defined? | Mapping Defined? | Header Name |
+|------|---------------------|------------------|-------------|
+| Automatic | No | N/A | `Wanaku.<paramName>` |
+| Explicit (default name) | Yes | No | `<paramName>` |
+| Explicit (custom name) | Yes | Yes | `<mapping.name>` |
+
+## Parameter Mapping Strategies
+
+The capability supports two strategies for mapping MCP parameters to Camel headers. You choose a strategy per tool, not globally.
+
+### Strategy 1: Automatic Mapping (No Properties)
+
+When you omit the `properties` field, **all** MCP parameters are automatically mapped to Camel headers with a `Wanaku.` prefix.
+
+**Rules YAML**:
+
+```yaml
+mcp:
+  tools:
+    - get-employee-info:
+        route:
+          id: "get-employee-route"
+        description: "Retrieve employee information"
+```
+
+**AI agent invocation**:
+
+```json
+{
+  "employeeId": "12345",
+  "includeHistory": "true"
+}
+```
+
+**Camel headers created**:
+
+- `Wanaku.employeeId` → `"12345"`
+- `Wanaku.includeHistory` → `"true"`
+
+**Accessing in routes**:
+
+```yaml
+- route:
+    id: get-employee-route
+    from:
+      uri: direct:get-employee-route
+      steps:
+        - log:
+            message: "Fetching employee ${header.Wanaku.employeeId}"
+        - toD: "https://api.example.com/employees/${header.Wanaku.employeeId}"
+```
+
+**Pros**:
+
+- Simple configuration
+- All parameters are available
+- Flexible for prototyping
+
+**Cons**:
+
+- `Wanaku.` prefix required in routes
+- No parameter validation
+- No documentation for AI agents
+
+### Strategy 2: Explicit Mapping (With Properties)
+
+When you define `properties`, **only those properties are mapped** to Camel headers. Additional parameters sent by AI agents are ignored.
+
+**Rules YAML**:
+
+```yaml
+mcp:
+  tools:
+    - initiate-promotion:
+        route:
+          id: "promotion-route"
+        description: "Initiate employee promotion"
+        properties:
+          - name: employee
+            type: string
+            description: The employee ID
+            required: true
+            mapping:
+              type: header
+              name: EMPLOYEE
+          - name: newLevel
+            type: string
+            description: The new organizational level
+            required: true
+            mapping:
+              type: header
+              name: NEW_LEVEL
+```
+
+**AI agent invocation**:
+
+```json
+{
+  "employee": "EMP-789",
+  "newLevel": "Senior Manager",
+  "extraParam": "ignored"
+}
+```
+
+**Camel headers created**:
+
+- `EMPLOYEE` → `"EMP-789"`
+- `NEW_LEVEL` → `"Senior Manager"`
+- `extraParam` is **not mapped** (not defined in properties)
+
+**Accessing in routes**:
+
+```yaml
+- route:
+    id: promotion-route
+    from:
+      uri: direct:promotion-route
+      steps:
+        - log:
+            message: "Promoting ${header.EMPLOYEE} to ${header.NEW_LEVEL}"
+        - toD: "https://hr-api.example.com/promotions?emp=${header.EMPLOYEE}"
+```
+
+**Pros**:
+
+- Full control over header names
+- Parameter validation (required fields)
+- Clear API documentation for AI agents
+- Restricts which parameters reach the backend
+
+**Cons**:
+
+- More verbose configuration
+- Must update rules file when adding parameters
+
+### Choosing a Strategy
+
+| Use Case | Strategy |
+|----------|----------|
+| Prototyping, flexible parameters | Automatic |
+| Production, strict API contracts | Explicit |
+| Need custom header names | Explicit |
+| Want parameter validation | Explicit |
+| Simple pass-through scenarios | Automatic |
+
+**Best practice**: Start with automatic mapping during development. Switch to explicit mapping for production deployments.
+
+## Resource Definitions
+
+Resources are passive data sources. Unlike tools, they're not invoked — instead, AI agents subscribe to them or query them periodically.
+
+**Key difference from tools**:
+
+- **Tools**: Execute the route's logic (the route body)
+- **Resources**: Access only the route's endpoint URI via a consumer template (the route body is **not executed**)
+
+**Resource routes must have auto-start disabled**. Otherwise, the route starts consuming data at startup, which isn't what you want for resources.
+
+### Minimal Resource Definition
+
+```yaml
+mcp:
+  resources:
+    - employee-performance-history:
+        route:
+          id: "performance-history-route"
+        description: "Employee performance history records"
+```
+
+**Routes YAML** (note `autoStartup: false`):
+
+```yaml
+- route:
+    id: performance-history-route
+    autoStartup: false
+    from:
+      uri: sql:SELECT * FROM performance_reviews WHERE employee_id = :#employeeId
+```
+
+**How it works**:
+
+When an AI agent accesses the `employee-performance-history` resource, the capability:
+
+1. Looks up the route by ID (`performance-history-route`)
+2. Extracts the endpoint URI (`sql:SELECT ...`)
+3. Uses a Camel consumer template to fetch data from that endpoint
+4. Returns the data to the AI agent
+
+The route's `steps` (if any) are **not executed**. Only the endpoint is accessed.
+
+### Full Resource Definition
+
+```yaml
+mcp:
+  resources:
+    - employee-performance-history:
+        route:
+          id: "performance-history-route"
+        description: "Historical performance review records for employees"
+        namespace: hr-data
+```
+
+**Fields**:
+
+- **Resource name** (`employee-performance-history`): Identifier AI agents use. Must be unique.
+- **`route.id`** (required): ID of the Camel route. The route must have `autoStartup: false`.
+- **`description`** (required): Human-readable description.
+- **`namespace`** (optional): Namespace for organizing resources.
+
+### Resource Field Reference
+
+Same as tools, except:
+
+- **No `properties` field**: Resources don't have parameters in the same way tools do. Data is accessed via the endpoint URI, which may have its own parameter syntax (e.g., SQL query parameters).
+
+### Resource Constraints
+
+**1. Auto-start must be disabled**
+
+```yaml
+- route:
+    id: my-resource-route
+    autoStartup: false  # Required for resources
+    from:
+      uri: file:/data/reports?noop=true
+```
+
+If you forget this, the route starts consuming data at startup, which can cause:
+
+- Unwanted side effects (e.g., files being moved or deleted)
+- Resource contention
+- Confusing behavior (the route is running but it's supposed to be a passive resource)
+
+**2. Data must be convertible to String**
+
+The capability returns resource data as a string. If the endpoint returns binary data or complex objects, ensure they can be serialized to a string (e.g., JSON, XML, CSV).
+
+**Example (SQL resource)**:
+
+```yaml
+- route:
+    id: employee-data-resource
+    autoStartup: false
+    from:
+      uri: sql:SELECT * FROM employees WHERE department = 'Engineering'
+      steps:
+        - marshal:
+            json: {}  # Convert result to JSON string
+```
+
+The marshaling step ensures the data is a JSON string, which the capability can return to the AI agent.
+
+## Complete Examples
+
+### Example 1: Automatic Mapping (Minimal Configuration)
+
+**Routes YAML**:
+
+```yaml
+- route:
+    id: get-employee
+    from:
+      uri: direct:get-employee
+      steps:
+        - log:
+            message: "Fetching employee ${header.Wanaku.employeeId}"
+        - toD: "https://api.example.com/employees/${header.Wanaku.employeeId}"
+```
+
+**Rules YAML**:
+
+```yaml
+mcp:
+  tools:
+    - get-employee-info:
+        route:
+          id: "get-employee"
+        description: "Retrieve employee information by ID"
+```
+
+**Result**: All parameters are mapped to headers with `Wanaku.` prefix.
+
+### Example 2: Explicit Mapping with Multiple Parameters
+
+**Routes YAML**:
+
+```yaml
+- route:
+    id: update-inventory
+    from:
+      uri: direct:update-inventory
+      steps:
+        - log:
+            message: "Updating inventory: SKU=${header.SKU}, Quantity=${header.QUANTITY}"
+        - setHeader:
+            name: CamelHttpMethod
+            constant: POST
+        - toD: "https://inventory-api.example.com/items/${header.SKU}?quantity=${header.QUANTITY}"
+```
+
+**Rules YAML**:
+
+```yaml
+mcp:
+  tools:
+    - update-inventory-quantity:
+        route:
+          id: "update-inventory"
+        description: "Update the quantity of an inventory item"
+        namespace: inventory-operations
+        properties:
+          - name: sku
+            type: string
+            description: The SKU of the item to update
+            required: true
+            mapping:
+              type: header
+              name: SKU
+          - name: quantity
+            type: int
+            description: The new quantity value
+            required: true
+            mapping:
+              type: header
+              name: QUANTITY
+```
+
+**Result**: Only `sku` and `quantity` are mapped. Headers are named `SKU` and `QUANTITY`.
+
+### Example 3: Tool and Resource in One File
+
+**Routes YAML**:
+
+```yaml
+- route:
+    id: send-email
+    from:
+      uri: direct:send-email
+      steps:
+        - log:
+            message: "Sending email to ${header.Wanaku.recipient}"
+        - toD: "smtp://mail.example.com?to=${header.Wanaku.recipient}"
+
+- route:
+    id: email-templates
+    autoStartup: false
+    from:
+      uri: file:/data/email-templates?noop=true
+      steps:
+        - convertBodyTo:
+            type: String
+```
+
+**Rules YAML**:
+
+```yaml
+mcp:
+  tools:
+    - send-notification-email:
+        route:
+          id: "send-email"
+        description: "Send a notification email to a recipient"
+        namespace: notifications
+
+  resources:
+    - email-templates:
+        route:
+          id: "email-templates"
+        description: "Available email templates for notifications"
+        namespace: notifications
+```
+
+**Result**:
+
+- Tool: `send-notification-email` (invocable, sends email)
+- Resource: `email-templates` (passive, AI agents can query available templates)
+
+### Example 4: Multiple Tools Mapping to the Same Route
+
+**Routes YAML**:
+
+```yaml
+- route:
+    id: query-database
+    from:
+      uri: direct:query-database
+      steps:
+        - toD: "sql:${header.SQL_QUERY}"
+```
+
+**Rules YAML**:
+
+```yaml
+mcp:
+  tools:
+    - get-active-employees:
+        route:
+          id: "query-database"
+        description: "Get all active employees"
+        properties:
+          - name: department
+            type: string
+            description: Filter by department
+            required: false
+            mapping:
+              type: header
+              name: DEPARTMENT
+
+    - get-employee-count:
+        route:
+          id: "query-database"
+        description: "Count employees in a department"
+        properties:
+          - name: department
+            type: string
+            description: Department to count
+            required: true
+            mapping:
+              type: header
+              name: DEPARTMENT
+```
+
+**Result**: Two tools, same route, different parameter mappings. Each tool can pre-configure the SQL query differently (e.g., via headers or route logic).
+
+## Validation and Error Handling
+
+### Route ID Not Found
+
+If `route.id` doesn't match any loaded route:
+
+```
+ERROR Route 'unknown-route-id' not found
+```
+
+The tool is registered with Wanaku but invocations will fail. Verify:
+
+- Route ID is spelled correctly (case-sensitive)
+- Route loaded successfully (check logs for route loading errors)
+
+### Missing Required Field
+
+If a required field is missing:
+
+```
+ERROR Tool 'my-tool' is missing required field 'description'
+```
+
+Fix by adding the missing field.
+
+### Invalid YAML Syntax
+
+If the rules YAML is malformed:
+
+```
+ERROR Failed to parse rules file: expected <block end>, but found '<scalar>'
+```
+
+Use a YAML linter to validate syntax:
+
+```bash
+yamllint rules.yaml
+```
+
+### Resource Route with autoStartup Enabled
+
+If a resource route has `autoStartup: true` (or defaults to true):
+
+```
+WARN Resource route 'my-resource-route' has auto-start enabled. This may cause unexpected behavior.
+```
+
+The service may log a warning but won't fail. However, the route will start consuming data at startup, which is usually not what you want for resources.
+
+**Fix**: Add `autoStartup: false` to the route definition.
+
+## Best Practices
+
+### Tool Naming
+
+- Use action verbs: `get-employee-info`, `update-inventory`, `send-email`
+- Be specific: `get-active-employees` is clearer than `get-employees`
+- Use kebab-case: `send-notification-email` (not `sendNotificationEmail` or `send_notification_email`)
+
+### Descriptions
+
+- Write for AI agents, not humans. AI agents parse descriptions to decide when to use tools.
+- Be concise but complete: "Retrieve employee information including name, title, and department"
+- Mention side effects: "Sends a confirmation email after updating the record"
+- Avoid implementation details: Don't say "Calls the /api/v1/employees endpoint via HTTP GET"
+
+### Namespaces
+
+- Group related tools: All HR tools in `hr-operations`, all inventory tools in `inventory`
+- Use consistent naming: `hr-operations`, `hr-data` (not `hr`, `HR-Ops`, `humanResources`)
+- Don't over-namespace: If you only have 3 tools, a single namespace is fine
+
+### Parameter Definitions
+
+- Start with automatic mapping (no `properties`)
+- Switch to explicit mapping when you need validation or custom header names
+- Document every parameter: AI agents rely on descriptions to understand what to send
+- Mark parameters as `required: true` if they're mandatory
+- Use descriptive parameter names: `employeeId` is clearer than `id`
+
+### Resource Routes
+
+- Always set `autoStartup: false`
+- Ensure data is convertible to String (use marshaling if needed)
+- Use resources for read-only data sources (databases, files, APIs)
+- Don't use resources for operations that modify state (use tools instead)
+
+### Testing Your Rules
+
+Before deploying to production:
+
+1. **Validate YAML syntax**:
+   ```bash
+   yamllint rules.yaml
+   ```
+
+2. **Check route IDs match**:
+   ```bash
+   grep "id:" routes.camel.yaml
+   grep "id:" rules.yaml
+   ```
+
+3. **Test with fail-fast enabled**:
+   ```bash
+   --fail-fast=true
+   ```
+
+   This catches errors early (e.g., missing routes, invalid syntax).
+
+4. **Invoke each tool manually** (via Wanaku's API or a test script) to verify parameter mapping works as expected.

--- a/docs/service-catalog-guide.md
+++ b/docs/service-catalog-guide.md
@@ -1,0 +1,539 @@
+# Service Catalog Guide
+
+Service catalogs are the recommended way to package and distribute Apache Camel routes for the Camel Integration Capability. Instead of managing individual files for routes, rules, and dependencies, a catalog bundles everything into a single versioned artifact.
+
+## What is a Service Catalog?
+
+A service catalog is a versioned ZIP archive stored in Wanaku's DataStore. It packages together:
+
+- **Routes**: Apache Camel route definitions (YAML)
+- **Rules**: Route exposure rules defining which routes become MCP tools or resources
+- **Dependencies**: External JARs needed by your routes (optional)
+
+One catalog can contain resources for multiple systems. Each system gets its own subdirectory within the ZIP.
+
+## Why Use Service Catalogs?
+
+Service catalogs solve real operational headaches:
+
+**Atomic Updates**: When you change a route's signature, you often need to update both the route logic and the exposure rules. With individual files, there's a window where the service might pull the new route but old rules. Catalogs eliminate that — everything updates together.
+
+**Version Control**: Production deployments need reproducibility. `employee-system-v2` means exactly that version of routes, rules, and dependencies, every time. No hunting through git history to figure out which files match which deployment.
+
+**Simplified Configuration**: Compare these two deployment commands:
+
+**Without catalog** (three moving parts):
+```bash
+--routes-ref datastore://routes.camel.yaml \
+--rules-ref datastore://rules.yaml \
+--dependencies datastore://deps.txt
+```
+
+**With catalog** (one reference):
+```bash
+--service-catalog employee-system-v2 \
+--service-catalog-system employee-system
+```
+
+The catalog approach scales better when you're managing multiple environments or multiple systems.
+
+## Catalog Structure
+
+A service catalog ZIP must contain an `index.properties` file at the root. This file maps system names to their resources within the archive.
+
+### Example Catalog Layout
+
+```
+employee-system-v2.zip
+├── index.properties
+└── employee-system/
+    ├── routes.camel.yaml
+    ├── rules.wanaku-rules.yaml
+    └── dependencies.txt
+```
+
+You can include multiple systems in one catalog:
+
+```
+hr-systems-v3.zip
+├── index.properties
+├── employee-system/
+│   ├── routes.camel.yaml
+│   ├── rules.wanaku-rules.yaml
+│   └── dependencies.txt
+└── payroll-system/
+    ├── routes.camel.yaml
+    ├── rules.wanaku-rules.yaml
+    └── dependencies.txt
+```
+
+### index.properties Schema
+
+The `index.properties` file defines the catalog's metadata and maps each system to its resources.
+
+**Minimal example (single system):**
+
+```properties
+catalog.name=employee-system-v2
+catalog.services=employee-system
+catalog.routes.employee-system=employee-system/routes.camel.yaml
+catalog.rules.employee-system=employee-system/rules.wanaku-rules.yaml
+```
+
+**With dependencies:**
+
+```properties
+catalog.name=employee-system-v2
+catalog.services=employee-system
+catalog.routes.employee-system=employee-system/routes.camel.yaml
+catalog.rules.employee-system=employee-system/rules.wanaku-rules.yaml
+catalog.dependencies.employee-system=employee-system/dependencies.txt
+```
+
+**Multiple systems:**
+
+```properties
+catalog.name=hr-systems-v3
+catalog.services=employee-system,payroll-system
+catalog.routes.employee-system=employee-system/routes.camel.yaml
+catalog.rules.employee-system=employee-system/rules.wanaku-rules.yaml
+catalog.dependencies.employee-system=employee-system/dependencies.txt
+catalog.routes.payroll-system=payroll-system/routes.camel.yaml
+catalog.rules.payroll-system=payroll-system/rules.wanaku-rules.yaml
+catalog.dependencies.payroll-system=payroll-system/dependencies.txt
+```
+
+#### Property Reference
+
+| Property | Required | Description |
+|----------|----------|-------------|
+| `catalog.name` | Yes | Unique identifier for this catalog. Must match the value passed to `--service-catalog`. |
+| `catalog.services` | Yes | Comma-separated list of system names included in this catalog. |
+| `catalog.routes.<system>` | Yes | Path within the ZIP to the Camel routes YAML for `<system>`. |
+| `catalog.rules.<system>` | Yes | Path within the ZIP to the exposure rules YAML for `<system>`. |
+| `catalog.dependencies.<system>` | No | Path within the ZIP to the dependencies file for `<system>`. Omit if no external dependencies are needed. |
+
+**Important constraints:**
+
+- All paths in `index.properties` are relative to the root of the ZIP archive.
+- The paths must match the actual file locations inside the ZIP. Case-sensitive.
+- `catalog.name` is used as the catalog identifier when running the service with `--service-catalog`.
+- Each system listed in `catalog.services` must have at least `catalog.routes.<system>` and `catalog.rules.<system>` defined.
+
+## Creating a Service Catalog
+
+### Step 1: Organize Your Files
+
+Create a directory structure matching the catalog layout:
+
+```bash
+mkdir -p my-catalog/employee-system
+cd my-catalog
+```
+
+Place your routes, rules, and dependencies in the system directory:
+
+```bash
+# Example files
+employee-system/routes.camel.yaml         # Camel routes
+employee-system/rules.wanaku-rules.yaml   # Exposure rules
+employee-system/dependencies.txt          # Dependencies (optional)
+```
+
+### Step 2: Create index.properties
+
+In the `my-catalog` directory, create `index.properties`:
+
+```properties
+catalog.name=employee-system-v2
+catalog.services=employee-system
+catalog.routes.employee-system=employee-system/routes.camel.yaml
+catalog.rules.employee-system=employee-system/rules.wanaku-rules.yaml
+catalog.dependencies.employee-system=employee-system/dependencies.txt
+```
+
+Verify the paths. If `rules.wanaku-rules.yaml` is actually named `exposure-rules.yaml` in your directory, the catalog won't work. The property value must match the real filename.
+
+### Step 3: Package the Catalog
+
+Use the `zip` command to create the archive:
+
+```bash
+zip -r employee-system-v2.zip index.properties employee-system/
+```
+
+**What this does:**
+
+- Creates `employee-system-v2.zip` containing `index.properties` and the `employee-system/` directory.
+- The `-r` flag ensures subdirectories are included recursively.
+
+**Verify the structure:**
+
+```bash
+unzip -l employee-system-v2.zip
+```
+
+Expected output:
+
+```
+Archive:  employee-system-v2.zip
+  Length      Date    Time    Name
+---------  ---------- -----   ----
+      243  2026-01-15 14:32   index.properties
+        0  2026-01-15 14:30   employee-system/
+     1842  2026-01-15 14:30   employee-system/routes.camel.yaml
+      567  2026-01-15 14:31   employee-system/rules.wanaku-rules.yaml
+       89  2026-01-15 14:31   employee-system/dependencies.txt
+---------                     -------
+     2741                     5 files
+```
+
+If `index.properties` is nested inside a subdirectory (e.g., `my-catalog/index.properties` instead of `index.properties`), the catalog is broken. The capability expects `index.properties` at the root of the ZIP.
+
+## Publishing a Service Catalog
+
+Upload the catalog ZIP to Wanaku's DataStore. The exact mechanism depends on your Wanaku deployment, but typically:
+
+**Using Wanaku's DataStore API:**
+
+```bash
+curl -X POST http://wanaku-datastore:8080/api/v1/catalogs \
+  -H "Content-Type: multipart/form-data" \
+  -H "Authorization: Bearer $TOKEN" \
+  -F "file=@employee-system-v2.zip"
+```
+
+**Using the Wanaku CLI (if available):**
+
+```bash
+wanaku datastore upload employee-system-v2.zip --type catalog
+```
+
+After uploading, the catalog is referenced by its `catalog.name` from `index.properties` — in this case, `employee-system-v2`.
+
+## Using a Service Catalog
+
+Once published, reference the catalog when starting the Camel Integration Capability.
+
+### CLI Deployment
+
+```bash
+java -jar camel-integration-capability-main-*-jar-with-dependencies.jar \
+  --registration-url http://wanaku-router:8080 \
+  --registration-announce-address my-service.example.com \
+  --service-catalog employee-system-v2 \
+  --service-catalog-system employee-system \
+  --client-id wanaku-service \
+  --client-secret your-secret
+```
+
+**Parameters:**
+
+- `--service-catalog`: The `catalog.name` from `index.properties`
+- `--service-catalog-system`: The system name within the catalog (must be listed in `catalog.services`)
+
+The capability will:
+
+1. Register with the Wanaku router
+2. Download `employee-system-v2.zip` from the DataStore
+3. Extract the files for `employee-system` (routes, rules, dependencies)
+4. Load the routes and start serving them as MCP tools
+
+If the download fails, the capability retries with exponential backoff (up to `--retries`, default 12).
+
+### Kubernetes Deployment
+
+```yaml
+apiVersion: "wanaku.ai/v1alpha1"
+kind: Wanaku
+metadata:
+  name: wanaku-dev
+spec:
+  auth:
+    authServer: http://keycloak:8543
+    authProxy: "auto"
+  router:
+    image: quay.io/wanaku/wanaku-router-backend:latest
+  secrets:
+    oidcCredentialsSecret: wanaku-credentials
+  capabilities:
+    - name: employee-system
+      type: camel-integration-capability
+      image: quay.io/wanaku/camel-integration-capability:latest
+      env:
+        - name: SERVICE_CATALOG
+          value: "employee-system-v2"
+        - name: SERVICE_CATALOG_SYSTEM
+          value: "employee-system"
+```
+
+The Wanaku operator injects `REGISTRATION_URL`, `CLIENT_ID`, and `CLIENT_SECRET` automatically.
+
+## Versioning Best Practices
+
+Service catalogs are immutable artifacts. Once deployed, `employee-system-v2` should always reference the same routes, rules, and dependencies.
+
+### Recommended Naming Convention
+
+Use descriptive names with version suffixes:
+
+- `employee-system-v2` — version 2 of the employee system catalog
+- `payroll-system-2026-01` — payroll catalog for January 2026 release
+- `hr-systems-prod-2.3.1` — HR systems catalog, production version 2.3.1
+
+Avoid generic names like `latest` or `current` — these defeat the purpose of versioning.
+
+### Version Lifecycle
+
+**Development**: Create a catalog with a `-dev` or `-snapshot` suffix:
+
+```properties
+catalog.name=employee-system-v3-dev
+```
+
+Deploy and test it in a development environment. The catalog can be overwritten during active development.
+
+**Staging**: Promote the catalog to a release candidate version:
+
+```properties
+catalog.name=employee-system-v3-rc1
+```
+
+Deploy to staging. This catalog should not be modified. If changes are needed, create `v3-rc2`.
+
+**Production**: Finalize the version:
+
+```properties
+catalog.name=employee-system-v3
+```
+
+Deploy to production. This catalog is now immutable. Future changes require `v4`.
+
+### When to Create a New Version
+
+Create a new catalog version when:
+
+- **Route signatures change**: Adding, removing, or renaming route parameters
+- **Dependencies change**: Upgrading a library, adding a new component
+- **Business logic changes**: Modifying route behavior in a non-trivial way
+
+You don't need a new version for:
+
+- **Comment updates** in YAML
+- **Log message changes** (unless they're part of the tool's contract)
+- **Non-functional refactors** that don't alter route behavior
+
+## Catalog vs Individual File References
+
+The Camel Integration Capability supports two modes:
+
+| Approach | When to Use |
+|----------|-------------|
+| **Service Catalog** | Production deployments, versioned releases, managing multiple systems |
+| **Individual Files** | Development, prototyping, debugging a single route |
+
+### Using Individual Files (Development Mode)
+
+During development, it's often easier to iterate on a single route file without packaging a full catalog:
+
+```bash
+java -jar camel-integration-capability-main-*-jar-with-dependencies.jar \
+  --registration-url http://localhost:8080 \
+  --registration-announce-address localhost \
+  --routes-ref file:///workspace/routes.camel.yaml \
+  --rules-ref file:///workspace/rules.yaml \
+  --client-id wanaku-service \
+  --client-secret test-secret
+```
+
+This mode allows you to edit `routes.camel.yaml` and restart the service without rebuilding a ZIP.
+
+**Important constraint**: `--service-catalog` is mutually exclusive with `--routes-ref`, `--rules-ref`, and `--dependencies`. The service rejects configurations that mix both approaches.
+
+### Transitioning to Catalogs
+
+Once your routes stabilize, transition to catalogs for deployment:
+
+1. Create the catalog directory structure
+2. Copy your working routes, rules, and dependencies into it
+3. Write `index.properties`
+4. Package the ZIP
+5. Upload to Wanaku's DataStore
+6. Update your deployment to use `--service-catalog`
+
+Catalogs are the path from "it works on my machine" to "it works the same way every time."
+
+## Troubleshooting
+
+### Catalog Download Failures
+
+**Symptom**: Logs show repeated download attempts, eventually timing out.
+
+**Check**:
+
+1. Verify the catalog exists in Wanaku's DataStore:
+   ```bash
+   curl -H "Authorization: Bearer $TOKEN" \
+     http://wanaku-datastore:8080/api/v1/catalogs/employee-system-v2
+   ```
+
+2. Verify the `catalog.name` in `index.properties` matches `--service-catalog`:
+   ```bash
+   unzip -p employee-system-v2.zip index.properties | grep catalog.name
+   ```
+
+3. Check OAuth2 token acquisition:
+   - The service needs a valid token to download catalogs
+   - Look for `Failed to acquire token` in logs
+   - Verify `--client-id` and `--client-secret` are correct
+
+4. Check network connectivity:
+   ```bash
+   kubectl exec deployment/camel-integration-capability -- \
+     curl -v http://wanaku-datastore:8080/health
+   ```
+
+### System Not Found in Catalog
+
+**Symptom**: Error like `System 'employee-system' not found in catalog 'hr-systems-v3'`.
+
+**Cause**: The system name passed to `--service-catalog-system` isn't listed in `catalog.services` in `index.properties`.
+
+**Fix**:
+
+1. List the available systems:
+   ```bash
+   unzip -p hr-systems-v3.zip index.properties | grep catalog.services
+   ```
+
+2. Use the exact system name (case-sensitive):
+   ```bash
+   --service-catalog-system payroll-system
+   ```
+
+### Missing Files in Extracted Catalog
+
+**Symptom**: `FileNotFoundException: employee-system/routes.camel.yaml not found`.
+
+**Cause**: The paths in `index.properties` don't match the actual file locations in the ZIP.
+
+**Debug**:
+
+1. List the ZIP contents:
+   ```bash
+   unzip -l employee-system-v2.zip
+   ```
+
+2. Compare to `index.properties`:
+   ```bash
+   unzip -p employee-system-v2.zip index.properties
+   ```
+
+3. Paths are case-sensitive and must match exactly. If the ZIP contains `Employee-System/Routes.yaml` but `index.properties` says `employee-system/routes.camel.yaml`, it won't work.
+
+### Malformed index.properties
+
+**Symptom**: Parsing errors when loading the catalog.
+
+**Common mistakes**:
+
+- **Missing required properties**: Every system needs `catalog.routes.<system>` and `catalog.rules.<system>`.
+- **Typos in system names**: `catalog.routes.employee-system` but `catalog.rules.employe-system` (missing 'e').
+- **Wrong separator**: Use commas in `catalog.services`, not spaces or semicolons.
+- **Special characters**: Avoid spaces or special characters in system names. Use `employee-system`, not `employee system`.
+
+**Validate**:
+
+```bash
+unzip -p employee-system-v2.zip index.properties
+```
+
+Check that:
+- `catalog.name` is present
+- `catalog.services` lists all systems
+- Each system has `catalog.routes.<system>` and `catalog.rules.<system>`
+
+## Advanced: Multi-System Catalogs
+
+Large organizations often manage multiple related systems. Multi-system catalogs let you version them together.
+
+### Example: HR Systems Catalog
+
+```
+hr-systems-v3.zip
+├── index.properties
+├── employee-system/
+│   ├── routes.camel.yaml
+│   ├── rules.wanaku-rules.yaml
+│   └── dependencies.txt
+├── payroll-system/
+│   ├── routes.camel.yaml
+│   └── rules.wanaku-rules.yaml
+└── benefits-system/
+    ├── routes.camel.yaml
+    ├── rules.wanaku-rules.yaml
+    └── dependencies.txt
+```
+
+**index.properties:**
+
+```properties
+catalog.name=hr-systems-v3
+catalog.services=employee-system,payroll-system,benefits-system
+catalog.routes.employee-system=employee-system/routes.camel.yaml
+catalog.rules.employee-system=employee-system/rules.wanaku-rules.yaml
+catalog.dependencies.employee-system=employee-system/dependencies.txt
+catalog.routes.payroll-system=payroll-system/routes.camel.yaml
+catalog.rules.payroll-system=payroll-system/rules.wanaku-rules.yaml
+catalog.routes.benefits-system=benefits-system/routes.camel.yaml
+catalog.rules.benefits-system=benefits-system/rules.wanaku-rules.yaml
+catalog.dependencies.benefits-system=benefits-system/dependencies.txt
+```
+
+**Deploying multiple systems:**
+
+Each capability instance references one system from the catalog:
+
+```yaml
+capabilities:
+  - name: employee-system
+    type: camel-integration-capability
+    image: quay.io/wanaku/camel-integration-capability:latest
+    env:
+      - name: SERVICE_CATALOG
+        value: "hr-systems-v3"
+      - name: SERVICE_CATALOG_SYSTEM
+        value: "employee-system"
+
+  - name: payroll-system
+    type: camel-integration-capability
+    image: quay.io/wanaku/camel-integration-capability:latest
+    env:
+      - name: SERVICE_CATALOG
+        value: "hr-systems-v3"
+      - name: SERVICE_CATALOG_SYSTEM
+        value: "payroll-system"
+
+  - name: benefits-system
+    type: camel-integration-capability
+    image: quay.io/wanaku/camel-integration-capability:latest
+    env:
+      - name: SERVICE_CATALOG
+        value: "hr-systems-v3"
+      - name: SERVICE_CATALOG_SYSTEM
+        value: "benefits-system"
+```
+
+All three services pull the same catalog ZIP but extract different systems. This ensures version alignment — if the employee and payroll systems share data models or integration contracts, they're guaranteed to be in sync.
+
+**When to use multi-system catalogs:**
+
+- Systems share dependencies or common integration logic
+- You need atomic version updates across related systems
+- Systems integrate with each other (e.g., employee promotion triggers payroll update)
+
+**When to use separate catalogs:**
+
+- Systems have independent release cycles
+- Teams manage systems separately
+- Systems rarely change together

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,924 @@
+# Troubleshooting Guide
+
+This guide walks through common issues when running the Camel Integration Capability and how to diagnose them. Organized by symptom, not cause — start with what you're seeing in the logs or behavior.
+
+## Routes Not Loading
+
+**Symptom**: The service starts, registers with Wanaku, but doesn't expose any tools or resources. Logs may show route loading failures.
+
+### Check Route YAML Syntax
+
+Invalid YAML syntax causes routes to fail silently (unless `--fail-fast` is enabled).
+
+**Validate locally**:
+
+```bash
+# Use yamllint or a YAML parser
+yamllint routes.camel.yaml
+
+# Or use Camel's validation (if you have Camel installed)
+camel validate routes.camel.yaml
+```
+
+**Common syntax errors**:
+
+- **Incorrect indentation**: YAML requires consistent spaces (not tabs)
+- **Missing colons**: `from` instead of `from:`
+- **Unquoted special characters**: URIs with query parameters need quotes
+
+**Example of invalid YAML**:
+
+```yaml
+- route:
+    id: example
+    from:
+    uri: direct:start  # Wrong indentation
+```
+
+**Correct version**:
+
+```yaml
+- route:
+    id: example
+    from:
+      uri: direct:start
+```
+
+Validate your routes using [Kaoto](https://kaoto.io) or [Apache Camel Karavan](https://camel.apache.org/karavan) — both provide visual editors with built-in validation.
+
+### Verify Route Reference URI
+
+If the route file can't be found or downloaded, routes won't load.
+
+**Check the URI scheme**:
+
+- `datastore://routes.camel.yaml` — downloads from Wanaku's DataStore after registration
+- `file:///absolute/path/routes.camel.yaml` — loads from local filesystem
+
+**For datastore:// URIs**:
+
+1. Verify the file exists in Wanaku's DataStore:
+   ```bash
+   curl -H "Authorization: Bearer $TOKEN" \
+     http://wanaku-datastore:8080/api/v1/files/routes.camel.yaml
+   ```
+
+2. Check that OAuth2 authentication succeeded (DataStore requires a token).
+
+3. Look for download retry attempts in logs:
+   ```
+   INFO  Attempting to download datastore://routes.camel.yaml (attempt 1/12)
+   ERROR Failed to download routes.camel.yaml: 404 Not Found
+   ```
+
+**For file:// URIs**:
+
+1. Verify the path is absolute, not relative:
+   ```bash
+   # Wrong (relative path)
+   --routes-ref file://routes.camel.yaml
+
+   # Correct (absolute path)
+   --routes-ref file:///tmp/routes.camel.yaml
+   ```
+
+2. Check file permissions:
+   ```bash
+   ls -la /tmp/routes.camel.yaml
+   ```
+
+   The service must have read access. In Kubernetes, this often means the file is in a mounted ConfigMap or volume.
+
+3. In Kubernetes, exec into the pod and verify:
+   ```bash
+   kubectl exec deployment/camel-integration-capability -- ls -la /data/routes.camel.yaml
+   ```
+
+### Check for Missing Dependencies
+
+Routes that reference Camel components not in the base distribution will fail to load.
+
+**Symptom**: Logs show `NoClassDefFoundError` or `Failed to create endpoint` errors.
+
+**Example**:
+
+```
+ERROR Failed to create route: No component found with name 'http'
+```
+
+This means the route uses `camel-http` but it's not on the classpath.
+
+**Fix**: Provide a dependencies file:
+
+```
+org.apache.camel:camel-http:4.18.1
+```
+
+Reference it with `--dependencies`:
+
+```bash
+--dependencies datastore://dependencies.txt
+```
+
+Or include it in your service catalog's `catalog.dependencies.<system>` property.
+
+**Common missing components**:
+
+| Route uses | Dependency |
+|------------|------------|
+| `http://` or `https://` | `org.apache.camel:camel-http:4.18.1` |
+| `sql:` | `org.apache.camel:camel-sql:4.18.1` |
+| `kafka:` | `org.apache.camel:camel-kafka:4.18.1` |
+| `jackson` marshaling | `org.apache.camel:camel-jackson:4.18.1` |
+| `aws2-s3:` | `org.apache.camel:camel-aws2-s3:4.18.1` |
+
+Check the [Camel Components documentation](https://camel.apache.org/components/latest/) to find the correct Maven coordinates for your component.
+
+### Understand --fail-fast Behavior
+
+By default, the service uses `--fail-fast=false`. This means:
+
+- If a route fails to load, the error is logged but **the service continues**
+- Other routes in the same file may load successfully
+- The service registers and serves the routes that *did* load
+
+**Check how many routes loaded**:
+
+```bash
+kubectl logs deployment/camel-integration-capability | grep "Started route"
+```
+
+If you see:
+
+```
+INFO Started route-1 (direct://route-1)
+INFO Started route-2 (direct://route-2)
+```
+
+But your rules expose three tools, one route didn't load.
+
+**Enable fail-fast for debugging**:
+
+```bash
+--fail-fast=true
+```
+
+With this flag, the service shuts down immediately if any route fails to load. Useful for catching errors early in development.
+
+### Enable Debug Logging for Route Loading
+
+Set the `WanakuRoutesLoader` logger to DEBUG:
+
+**Log4j2 configuration** (create or edit `log4j2.xml`):
+
+```xml
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Logger name="ai.wanaku.capability.camel.util.WanakuRoutesLoader" level="DEBUG"/>
+    <Root level="INFO">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>
+```
+
+Place this file on the classpath or reference it:
+
+```bash
+-Dlog4j.configurationFile=/config/log4j2.xml
+```
+
+In Kubernetes, mount it via ConfigMap:
+
+```yaml
+volumeMounts:
+  - name: log-config
+    mountPath: /config
+volumes:
+  - name: log-config
+    configMap:
+      name: log4j2-config
+```
+
+**Debug output shows**:
+
+- Which routes are being parsed
+- Dependency resolution for each route
+- Exact error messages when a route fails
+
+## Authentication Failures
+
+**Symptom**: Service fails to register, logs show OAuth2 token errors, or DataStore downloads fail with 401/403.
+
+### Verify Client Credentials
+
+Check `--client-id` and `--client-secret` match the OAuth2 provider's configuration.
+
+**For Keycloak**:
+
+1. Log into the Keycloak admin console
+2. Navigate to your realm → Clients
+3. Find the client ID (must match `--client-id`)
+4. Go to the Credentials tab
+5. Copy the client secret (must match `--client-secret`)
+
+**Common mistake**: Using the wrong realm or client. If you have multiple Keycloak realms, ensure you're referencing the right one.
+
+### Check Token Endpoint URL
+
+The `--token-endpoint` must point to the OAuth2/OIDC token endpoint. For Keycloak, **include the realm path**:
+
+**Wrong**:
+```bash
+--token-endpoint http://keycloak:8543/
+```
+
+**Correct**:
+```bash
+--token-endpoint http://keycloak:8543/realms/my-realm/
+```
+
+The service appends `/protocol/openid-connect/token` automatically, so the full URL becomes:
+
+```
+http://keycloak:8543/realms/my-realm/protocol/openid-connect/token
+```
+
+**Test token acquisition manually**:
+
+```bash
+curl -X POST http://keycloak:8543/realms/my-realm/protocol/openid-connect/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials" \
+  -d "client_id=wanaku-service" \
+  -d "client_secret=your-secret"
+```
+
+If this fails with 401, the credentials are wrong. If it returns a token, the service should work.
+
+### When Authentication is Disabled
+
+Some Wanaku deployments run without authentication (e.g., local development). In this case:
+
+**Omit `--client-secret`**:
+
+```bash
+java -jar camel-integration-capability-main-*-jar-with-dependencies.jar \
+  --registration-url http://localhost:8080 \
+  --registration-announce-address localhost \
+  --routes-ref file:///tmp/routes.camel.yaml \
+  --client-id wanaku-service
+```
+
+The service will skip OAuth2 token acquisition if no secret is provided.
+
+**Note**: `--client-id` is still required for service identification, even if authentication is disabled.
+
+### Check Network Connectivity to OAuth2 Provider
+
+If the token endpoint is unreachable, authentication will fail.
+
+**Test from the pod**:
+
+```bash
+kubectl exec deployment/camel-integration-capability -- \
+  curl -v http://keycloak:8543/realms/my-realm/
+```
+
+**Common issues**:
+
+- **DNS resolution failure**: The service can't resolve `keycloak` hostname. Check Kubernetes DNS or use an IP address.
+- **Firewall rules**: The pod's network policy blocks access to the OAuth2 provider.
+- **Wrong port**: Keycloak default is 8080 (HTTP) or 8443 (HTTPS), not 8543. Verify your deployment.
+
+### Token Refresh Errors
+
+The service acquires a token at startup and refreshes it periodically. If refresh fails, requests to Wanaku will start returning 401.
+
+**Check logs**:
+
+```bash
+kubectl logs deployment/camel-integration-capability | grep -i "token\|refresh"
+```
+
+Look for:
+
+```
+ERROR Failed to refresh OAuth2 token
+ERROR HTTP 401 Unauthorized when calling Wanaku API
+```
+
+**Cause**: The token expired and refresh failed, usually due to:
+
+- Client credentials changed in Keycloak
+- Network issues between the service and the OAuth2 provider
+- OAuth2 provider restarted and invalidated issued tokens
+
+**Fix**: Restart the service to acquire a fresh token:
+
+```bash
+kubectl rollout restart deployment/camel-integration-capability
+```
+
+## Dependency Download Failures
+
+**Symptom**: Routes using external libraries fail to load. Logs show Maven download errors.
+
+### Verify Maven Coordinates
+
+Dependencies must use the `groupId:artifactId:version` format:
+
+**Correct**:
+```
+org.apache.camel:camel-http:4.18.1
+com.mycompany:custom-beans:2.0.0
+```
+
+**Wrong**:
+```
+camel-http:4.18.1              # Missing groupId
+org.apache.camel:camel-http    # Missing version
+```
+
+**Check your dependencies file**:
+
+```bash
+cat dependencies.txt
+```
+
+Ensure it's comma-separated (or newline-separated):
+
+```
+org.apache.camel:camel-http:4.18.1,org.apache.camel:camel-jackson:4.18.1
+```
+
+Or:
+
+```
+org.apache.camel:camel-http:4.18.1
+org.apache.camel:camel-jackson:4.18.1
+```
+
+### Check Repository Access
+
+By default, the service downloads from Maven Central. If you're using a private repository or a corporate mirror, specify it with `--repositories`:
+
+```bash
+--repositories http://my-private-repo.com/maven,https://repo1.maven.org/maven2
+```
+
+**Test repository access**:
+
+```bash
+curl -I http://my-private-repo.com/maven/org/apache/camel/camel-http/4.18.1/camel-http-4.18.1.jar
+```
+
+If it returns 404 or 403, the repository isn't accessible or the artifact doesn't exist there.
+
+**For private repositories requiring authentication**, the service currently doesn't support authenticated Maven downloads. Workarounds:
+
+1. Use a repository proxy (e.g., Nexus, Artifactory) with anonymous access
+2. Pre-package dependencies in a custom Docker image
+3. Use the plugin mode and include dependencies in your application's classpath
+
+### Retry Behavior
+
+Dependency downloads retry with exponential backoff. Default settings:
+
+- Max retries: 12
+- Initial wait: 5 seconds
+- Exponential backoff multiplier: 2
+
+**Watch retry attempts**:
+
+```bash
+kubectl logs deployment/camel-integration-capability | grep -i "download\|retry"
+```
+
+You'll see:
+
+```
+INFO  Attempting to download org.apache.camel:camel-http:4.18.1 (attempt 1/12)
+WARN  Download failed, retrying in 5 seconds...
+INFO  Attempting to download org.apache.camel:camel-http:4.18.1 (attempt 2/12)
+```
+
+If all retries fail, the service gives up. Check the final error message for the root cause.
+
+### Verify Network Access to Maven Repositories
+
+**Test from the pod**:
+
+```bash
+kubectl exec deployment/camel-integration-capability -- \
+  curl -v https://repo1.maven.org/maven2/org/apache/camel/camel-http/4.18.1/camel-http-4.18.1.pom
+```
+
+If this times out or returns a connection error, the pod can't reach Maven Central. Possible causes:
+
+- **No internet egress**: The Kubernetes cluster blocks outbound traffic
+- **Proxy required**: Corporate networks often require HTTP proxies
+- **DNS issues**: Can't resolve `repo1.maven.org`
+
+**Fix for proxy environments**: Set Java proxy properties:
+
+```bash
+-Dhttp.proxyHost=proxy.company.com -Dhttp.proxyPort=8080 \
+-Dhttps.proxyHost=proxy.company.com -Dhttps.proxyPort=8080
+```
+
+In Kubernetes, add to the container args or via `JAVA_TOOL_OPTIONS`:
+
+```yaml
+env:
+  - name: JAVA_TOOL_OPTIONS
+    value: "-Dhttp.proxyHost=proxy.company.com -Dhttp.proxyPort=8080"
+```
+
+### Check --data-dir Permissions
+
+Downloaded dependencies are cached in `--data-dir` (default `/tmp`). If the service can't write to this directory, downloads fail.
+
+**Check permissions**:
+
+```bash
+kubectl exec deployment/camel-integration-capability -- ls -ld /tmp
+```
+
+Ensure the directory is writable. In some Kubernetes security contexts, `/tmp` might be read-only.
+
+**Fix**: Use a writable volume:
+
+```yaml
+volumeMounts:
+  - name: data
+    mountPath: /data
+volumes:
+  - name: data
+    emptyDir: {}
+```
+
+Then:
+
+```bash
+--data-dir /data
+```
+
+## Service Not Registering
+
+**Symptom**: The service starts, but never appears in Wanaku's service registry. AI agents can't invoke the tools.
+
+### Verify Registration URL
+
+The `--registration-url` must point to the Wanaku router's discovery service.
+
+**Test connectivity**:
+
+```bash
+curl http://wanaku-router:8080/discovery/services
+```
+
+If this fails, the service can't reach the router.
+
+**In Kubernetes**: Check that the service name resolves:
+
+```bash
+kubectl exec deployment/camel-integration-capability -- \
+  nslookup wanaku-router
+```
+
+If DNS fails, verify:
+
+- The router is running: `kubectl get pods -l app=wanaku-router`
+- The service exists: `kubectl get svc wanaku-router`
+
+### Check Registration Announce Address
+
+The `--registration-announce-address` is the address the router uses to call back to the capability.
+
+**Common mistake**: Using `localhost` in Kubernetes. The router can't reach `localhost` on another pod.
+
+**Correct for Kubernetes**:
+
+```bash
+--registration-announce-address camel-integration-capability.default.svc.cluster.local
+```
+
+Or use the pod's IP (less reliable if the pod restarts):
+
+```bash
+--registration-announce-address $(hostname -i)
+```
+
+**For local development** (router and capability on the same machine):
+
+```bash
+--registration-announce-address localhost
+```
+
+**Test if the router can reach the announced address**:
+
+From the router pod:
+
+```bash
+kubectl exec deployment/wanaku-router -- \
+  curl http://camel-integration-capability:9190/health
+```
+
+If this fails, the router can't call back. Check:
+
+- Firewall rules
+- Network policies
+- Service definitions
+
+### Review Retry Settings
+
+Registration retries up to `--retries` times (default 12), waiting `--wait-seconds` (default 5) between attempts.
+
+**Watch retry attempts**:
+
+```bash
+kubectl logs deployment/camel-integration-capability | grep -i "registration\|retry"
+```
+
+You'll see:
+
+```
+INFO  Attempting to register with Wanaku (attempt 1/12)
+WARN  Registration failed: Connection refused
+INFO  Waiting 5 seconds before retry...
+INFO  Attempting to register with Wanaku (attempt 2/12)
+```
+
+If it exhausts all retries, check the final error. Common causes:
+
+- **Connection refused**: Router isn't running or wrong port
+- **401 Unauthorized**: OAuth2 token acquisition failed
+- **500 Internal Server Error**: Router has a bug or misconfiguration
+
+### OAuth2 Token for Registration
+
+Registration requires authentication. If token acquisition fails, registration fails.
+
+**Check token acquisition**:
+
+```bash
+kubectl logs deployment/camel-integration-capability | grep -i "token\|oauth"
+```
+
+Look for:
+
+```
+INFO  Acquired OAuth2 token successfully
+```
+
+Or:
+
+```
+ERROR Failed to acquire OAuth2 token: invalid_client
+```
+
+If token acquisition fails, see the [Authentication Failures](#authentication-failures) section.
+
+### gRPC Server Must Start Before Registration
+
+The service starts a gRPC server on `--grpc-port` (default 9190) before attempting registration. If the port is already in use or binding fails, the pod won't register.
+
+**Check gRPC server startup**:
+
+```bash
+kubectl logs deployment/camel-integration-capability | grep -i "grpc\|port\|bind"
+```
+
+Look for:
+
+```
+INFO  gRPC server started on port 9190
+```
+
+Or:
+
+```
+ERROR Failed to bind to port 9190: Address already in use
+```
+
+**If port is in use**: Change the port:
+
+```bash
+--grpc-port 9191
+```
+
+**In Kubernetes**: Ensure the Service definition matches the gRPC port:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camel-integration-capability
+spec:
+  selector:
+    app: camel-integration-capability
+  ports:
+    - name: grpc
+      port: 9190
+      targetPort: 9190
+```
+
+If `targetPort` doesn't match `--grpc-port`, the router can't reach the service.
+
+## gRPC Connection Issues
+
+**Symptom**: Wanaku registers the service, but tool invocations fail with connection errors.
+
+### Default gRPC Port
+
+The service listens on port 9190 by default. Verify `--grpc-port` matches what the router expects.
+
+**Test the gRPC port**:
+
+```bash
+kubectl exec deployment/wanaku-router -- \
+  grpcurl -plaintext camel-integration-capability:9190 list
+```
+
+This should list the available gRPC services:
+
+```
+ai.wanaku.capability.grpc.CamelToolService
+ai.wanaku.capability.grpc.CamelResourceService
+```
+
+If it fails with `connection refused`, the port is wrong or the service isn't listening.
+
+### Check Firewall and Security Group Rules
+
+If the router and capability are in different networks, firewall rules might block gRPC traffic.
+
+**In cloud environments** (AWS, GCP, Azure):
+
+- Check security group rules allow ingress on port 9190
+- Verify the capability's service is exposed to the router's network
+
+**In Kubernetes**:
+
+- Check NetworkPolicies aren't blocking traffic
+- Verify the Service targets the correct pod port
+
+### In Kubernetes: Verify Service Configuration
+
+The Service resource must target the gRPC port:
+
+```bash
+kubectl get svc camel-integration-capability -o yaml
+```
+
+Look for:
+
+```yaml
+spec:
+  ports:
+    - name: grpc
+      port: 9190
+      targetPort: 9190
+  selector:
+    app: camel-integration-capability
+```
+
+**If the selector is wrong**, the Service won't route traffic to the pod. Fix:
+
+```bash
+kubectl label pod camel-integration-capability-... app=camel-integration-capability
+```
+
+### Test Connectivity with grpcurl
+
+`grpcurl` is a command-line tool for testing gRPC services.
+
+**Install grpcurl**:
+
+```bash
+go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
+```
+
+**Test from the router pod**:
+
+```bash
+kubectl exec deployment/wanaku-router -- \
+  grpcurl -plaintext camel-integration-capability:9190 \
+  ai.wanaku.capability.grpc.CamelToolService/InvokeTool
+```
+
+If this hangs or fails, gRPC connectivity is broken.
+
+## Service Catalog Issues
+
+**Symptom**: Using `--service-catalog` but the catalog doesn't download or fails to parse.
+
+### Verify Catalog Exists in DataStore
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  http://wanaku-datastore:8080/api/v1/catalogs/employee-system-v2
+```
+
+If it returns 404, the catalog wasn't uploaded or the name is wrong.
+
+### Check --service-catalog-system Matches index.properties
+
+The system name must be listed in `catalog.services`.
+
+**Download the catalog manually and inspect it**:
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  http://wanaku-datastore:8080/api/v1/catalogs/employee-system-v2 -o catalog.zip
+
+unzip -p catalog.zip index.properties
+```
+
+Look for:
+
+```properties
+catalog.services=employee-system,payroll-system
+```
+
+If your `--service-catalog-system` is `hr-system` but the catalog only lists `employee-system` and `payroll-system`, it will fail.
+
+### Service Catalogs are Mutually Exclusive with Individual References
+
+You can't mix `--service-catalog` with `--routes-ref`, `--rules-ref`, or `--dependencies`.
+
+**This will fail**:
+
+```bash
+--service-catalog employee-system-v2 \
+--service-catalog-system employee-system \
+--routes-ref datastore://routes.camel.yaml
+```
+
+**Error**:
+
+```
+--service-catalog is mutually exclusive with --routes-ref, --rules-ref, and --dependencies
+```
+
+**Fix**: Use one approach or the other, not both.
+
+### Download Retries with Exponential Backoff
+
+If catalog download fails, the service retries. Watch the logs:
+
+```bash
+kubectl logs deployment/camel-integration-capability | grep -i "catalog\|download"
+```
+
+You'll see:
+
+```
+INFO  Downloading service catalog 'employee-system-v2'
+WARN  Download failed, retrying in 5 seconds...
+INFO  Downloading service catalog 'employee-system-v2' (attempt 2/12)
+```
+
+If all retries fail, check:
+
+- OAuth2 token is valid
+- Catalog exists in DataStore
+- Network connectivity to DataStore
+
+## Debug Logging Configuration
+
+When troubleshooting, enable detailed logging to see what's happening inside the service.
+
+### Key Loggers
+
+| Logger | What It Shows |
+|--------|---------------|
+| `ai.wanaku.capability.camel.CamelToolMain` | Application startup, registration, initialization |
+| `ai.wanaku.capability.camel.grpc.CamelTool` | Tool invocations, parameter mapping, route execution |
+| `ai.wanaku.capability.camel.util.WanakuRoutesLoader` | Route loading, YAML parsing, dependency resolution |
+| `org.apache.camel` | Camel framework events (route starts, exchanges, errors) |
+| `ai.wanaku.capabilities.sdk` | Wanaku SDK internals (registration, token acquisition, API calls) |
+
+### Log4j2 Configuration
+
+Create a `log4j2.xml` file:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <!-- Capability-specific loggers -->
+    <Logger name="ai.wanaku.capability.camel" level="DEBUG"/>
+    <Logger name="ai.wanaku.capabilities.sdk" level="DEBUG"/>
+    
+    <!-- Camel framework (verbose, use sparingly) -->
+    <Logger name="org.apache.camel" level="INFO"/>
+    
+    <!-- Root logger -->
+    <Root level="INFO">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>
+```
+
+**Mount in Kubernetes**:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: log4j2-config
+data:
+  log4j2.xml: |
+    <?xml version="1.0" encoding="UTF-8"?>
+    <Configuration status="WARN">
+      <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+          <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+      </Appenders>
+      <Loggers>
+        <Logger name="ai.wanaku.capability.camel" level="DEBUG"/>
+        <Root level="INFO">
+          <AppenderRef ref="Console"/>
+        </Root>
+      </Loggers>
+    </Configuration>
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: camel-integration-capability
+spec:
+  template:
+    spec:
+      containers:
+        - name: capability
+          image: quay.io/wanaku/camel-integration-capability:latest
+          env:
+            - name: JAVA_TOOL_OPTIONS
+              value: "-Dlog4j.configurationFile=/config/log4j2.xml"
+          volumeMounts:
+            - name: log-config
+              mountPath: /config
+      volumes:
+        - name: log-config
+          configMap:
+            name: log4j2-config
+```
+
+**For local runs**:
+
+```bash
+-Dlog4j.configurationFile=/path/to/log4j2.xml
+```
+
+### What Debug Logs Reveal
+
+**Route loading**:
+
+```
+DEBUG WanakuRoutesLoader - Parsing routes from /data/routes.camel.yaml
+DEBUG WanakuRoutesLoader - Found 3 routes in YAML
+DEBUG WanakuRoutesLoader - Loading route 'get-employee-info'
+DEBUG WanakuRoutesLoader - Route 'get-employee-info' started successfully
+```
+
+**Dependency resolution**:
+
+```
+DEBUG DependencyDownloader - Downloading org.apache.camel:camel-http:4.18.1
+DEBUG DependencyDownloader - Resolved 12 transitive dependencies
+DEBUG DependencyDownloader - Downloaded camel-http-4.18.1.jar to /tmp/camel-deps/
+```
+
+**Tool invocations**:
+
+```
+DEBUG CamelTool - Received invocation for tool 'get-employee-info'
+DEBUG CamelTool - Mapping parameter 'employeeId' to header 'Wanaku.employeeId'
+DEBUG CamelTool - Executing route 'get-employee-info'
+DEBUG CamelTool - Route completed in 234ms
+```
+
+**Registration**:
+
+```
+DEBUG ZeroDepRegistrationManager - Attempting registration (attempt 1/12)
+DEBUG ZeroDepRegistrationManager - Acquired OAuth2 token
+DEBUG ZeroDepRegistrationManager - Registration successful, service ID: camel-12345
+```
+
+This level of detail makes it obvious where failures occur.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -25,6 +25,13 @@ This capability can be deployed in two ways:
 1. **Standalone Application** (this document) - Run as a separate service with CLI configuration
 2. **[Plugin Mode](plugin-usage.md)** - Embed into an existing Apache Camel application using SPI
 
+## Related Guides
+
+- **[CLI Reference](cli-reference.md)** - Complete command-line parameter reference
+- **[Service Catalog Guide](service-catalog-guide.md)** - Creating and publishing service catalogs
+- **[Rules Schema](rules-schema.md)** - Route exposure rules YAML reference
+- **[Troubleshooting](troubleshooting.md)** - Common issues and solutions
+
 ## Requirements
 
 - Java 21 or higher
@@ -263,6 +270,9 @@ Camel routes should be defined in YAML format in the file specified by `--routes
 ```
 
 ### Route Exposure Rules
+
+> [TIP]
+> For the complete rules YAML schema reference, see [Rules Schema](rules-schema.md).
 
 Routes can be exposed as MCP tools or resources by defining rules in a YAML file specified by `--rules-ref`.
 This file maps route definitions to tool specifications:
@@ -505,6 +515,9 @@ Route files can be provided to the capability using one of the following methods
 5. **Volume mounts**: Mount ConfigMaps or persistent volumes containing route files
 
 ### Using a Service Catalog
+
+> [TIP]
+> For a complete guide on creating and publishing service catalogs, see the [Service Catalog Guide](service-catalog-guide.md).
 
 This is the recommended way to obtain route files. A service catalog is a versioned ZIP archive stored in Wanaku
 that bundles all resources (routes, rules, and optionally dependencies) for one or more systems. Using a catalog


### PR DESCRIPTION
## Summary
- Add service catalog creation and publishing guide (structure, index.properties schema, packaging, versioning)
- Add troubleshooting guide organized by symptom (routes, auth, dependencies, registration, gRPC, debug logging)
- Add complete CLI parameter reference with all ~30 parameters, env variable mappings, and defaults
- Add rules YAML schema reference (tools, resources, properties, parameter mapping strategies)
- Update README.md with links to new documentation

## Test plan
- [ ] Verify service catalog guide matches source code behavior
- [ ] Verify CLI reference covers all parameters from CamelToolMain
- [ ] Verify rules schema matches actual YAML parsing
- [ ] Verify troubleshooting steps match known error patterns
- [ ] Verify README links are correct

## Summary by Sourcery

Add comprehensive user-facing documentation for configuring and operating the Camel Integration Capability, including service catalogs, CLI parameters, rules schema, and troubleshooting, and link it from the main README.

Documentation:
- Document the complete rules YAML schema for exposing Camel routes as MCP tools and resources, including parameter mapping strategies and examples.
- Add a troubleshooting guide organized by common symptoms covering routes, authentication, dependencies, registration, gRPC connectivity, service catalogs, and logging configuration.
- Provide a full CLI reference for the standalone application, detailing all parameters, environment variable mappings, defaults, and usage examples.
- Introduce a service catalog guide describing catalog structure, index.properties schema, versioning strategy, and deployment patterns, including multi-system catalogs.
- Update the README to reference the new service catalog guide, CLI reference, rules schema, and troubleshooting documentation.