### PR TITLE
chore: add markdownlint CI and fix existing violations

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,18 @@
+name: Markdown Lint
+
+on:
+  pull_request:
+    branches:
+      - "main"
+    paths:
+      - "docs/**/*.md"
+      - "*.md"
+      - "examples/**/README.md"
+      - ".markdownlint-cli2.yaml"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DavidAnson/markdownlint-cli2-action@v19

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,25 @@
+config:
+  MD004:
+    style: "dash"
+  MD013: false
+  MD024:
+    siblings_only: true
+  MD025: false
+  MD033: false
+  MD036: false
+  MD060: false
+
+globs:
+  - "docs/**/*.md"
+  - "*.md"
+  - "examples/**/README.md"
+
+ignores:
+  - ".oss-ai-helper-rules/**"
+  - ".claude/**"
+  - ".bob/**"
+  - ".specify/**"
+  - "specs/**"
+  - "CLAUDE.md"
+  - "target/**"
+  - "out/**"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,22 +18,26 @@ We expect all contributors to be respectful and professional. Create a welcoming
 ### Development Environment Setup
 
 1. **Clone the repository**:
+
    ```bash
    git clone https://github.com/wanaku-ai/camel-integration-capability.git
    cd camel-integration-capability
    ```
 
 2. **Build the project**:
+
    ```bash
    mvn clean install
    ```
 
 3. **Run tests**:
+
    ```bash
    mvn test
    ```
 
 4. **Run the application locally**:
+
    ```bash
    java -jar camel-integration-capability-runtimes/camel-integration-capability-main/target/camel-integration-capability-main-0.1.1-jar-with-dependencies.jar \
      --registration-url http://localhost:8080 \
@@ -49,7 +53,7 @@ We expect all contributors to be respectful and professional. Create a welcoming
 
 ## Project Structure
 
-```
+```text
 camel-integration-capability/
 ├── src/
 │   ├── main/
@@ -75,7 +79,7 @@ camel-integration-capability/
 ├── pom.xml                                 # Maven build configuration
 ├── Dockerfile                              # Container build definition
 └── README.md                               # Project overview
-```
+```text
 
 ## Development Workflow
 
@@ -86,6 +90,7 @@ git checkout -b feature/your-feature-name
 ```
 
 Use descriptive branch names:
+
 - `feature/add-http-basic-auth` - New features
 - `fix/route-loading-error` - Bug fixes
 - `docs/improve-readme` - Documentation updates
@@ -128,6 +133,7 @@ This resolves issue #<the issue number goes here>
 ```
 
 **Commit message format**:
+
 - **First line**: Brief summary (50 chars or less)
 - **Blank line**
 - **Body**: Detailed explanation of changes (wrap at 72 chars)
@@ -143,6 +149,7 @@ git push origin feature/your-feature-name
 ```
 
 Create a pull request on GitHub with:
+
 - **Clear title** describing the change
 - **Description** explaining what and why
 - **References** to related issues (e.g., "Fixes #123")
@@ -321,11 +328,12 @@ When requesting features, include:
 
 - **GitHub Issues**: Bug reports, feature requests, questions
 - **Pull Requests**: Code contributions, documentation improvements
-- **Email**: contact@wanaku.ai for general inquiries
+- **Email**: <contact@wanaku.ai> for general inquiries
 
 ## Recognition
 
 Contributors will be recognized in:
+
 - GitHub contributor list
 - Release notes for significant contributions
 - Project documentation where appropriate
@@ -336,4 +344,4 @@ By contributing, you agree that your contributions will be licensed under the Ap
 
 ---
 
-**Questions?** Open an issue or reach out to contact@wanaku.ai. We're here to help!
+**Questions?** Open an issue or reach out to <contact@wanaku.ai>. We're here to help!

--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ A capability service for the [Wanaku MCP Router](https://wanaku.ai) that enables
 
 ## What is This?
 
-The Camel Integration Capability bridges AI agents with enterprise integration patterns. 
+The Camel Integration Capability bridges AI agents with enterprise integration patterns.
 
 It exposes Apache Camel routes as MCP (Model Context Protocol) tools and resources, allowing AI agents to perform complex backend operations through standardized gRPC interfaces.
 
 **Key Use Cases:**
+
 - Enable AI agents to query databases, CRMs, or inventory systems
 - Orchestrate multi-step business workflows through natural language
 - Integrate AI capabilities with existing enterprise service buses
@@ -20,7 +21,7 @@ It exposes Apache Camel routes as MCP (Model Context Protocol) tools and resourc
 
 ## Project Structure
 
-```
+```text
 camel-integration-capability/
 ├── camel-integration-capability-common/           # Shared utilities, models, gRPC services
 └── camel-integration-capability-runtimes/
@@ -51,7 +52,6 @@ graph TB
     J[DataStore Service] -.->|Individual Resources| C
 ```
 
-
 ## Quick Start
 
 ### Prerequisites
@@ -64,6 +64,7 @@ graph TB
 ### 5-Minute Setup
 
 1. **Download the latest release** or build from source:
+
    ```bash
    git clone https://github.com/wanaku-ai/camel-integration-capability.git
    cd camel-integration-capability
@@ -71,6 +72,7 @@ graph TB
    ```
 
 2. **Prepare your Camel routes** (example `my-routes.camel.yaml`):
+
    ```yaml
    - route:
        id: get-employee-info
@@ -81,6 +83,7 @@ graph TB
    ```
 
 3. **Prepare route exposure rules** (example `my-rules.yaml`):
+
    ```yaml
    mcp:
      tools:
@@ -91,8 +94,8 @@ graph TB
    ```
 
    > [!NOTE]
-   > This example uses automatic parameter mapping. 
-   > All MCP parameters are mapped to Camel headers with the `Wanaku.` prefix (e.g., `employeeId` → `Wanaku.employeeId`). 
+   > This example uses automatic parameter mapping.
+   > All MCP parameters are mapped to Camel headers with the `Wanaku.` prefix (e.g., `employeeId` → `Wanaku.employeeId`).
    > For explicit control over parameter names, see the [Usage Guide](docs/usage.md#parameter-to-header-mapping).
 
 ### Option 1: Standalone Application
@@ -144,6 +147,8 @@ The plugin is automatically discovered via `META-INF/services/org.apache.camel.s
 > [!TIP]
 > Design your Camel routes visually using the [Kaoto Integration Designer](http://kaoto.io) for Apache Camel.
 
+<!-- -->
+
 > [!NOTE]
 > For detailed configuration options and deployment scenarios, see the [Usage Guide](docs/usage.md).
 
@@ -185,7 +190,7 @@ Deploy using the Wanaku operator. See [Usage Guide](docs/usage.md#deploying-the-
 
 - **Issues**: [GitHub Issues](https://github.com/wanaku-ai/camel-integration-capability/issues)
 - **Community**: [Wanaku](https://wanaku.ai)
-- **Email**: contact@wanaku.ai
+- **Email**: <contact@wanaku.ai>
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ Instead, report security vulnerabilities privately to ensure they can be address
 
 ### Reporting Process
 
-1. **Email**: Send a detailed report to **contact@wanaku.ai**
+1. **Email**: Send a detailed report to **<contact@wanaku.ai>**
 2. **Subject**: Use "SECURITY: [Brief Description]" in the subject line
 3. **Content**: Include the following information:
    - Description of the vulnerability
@@ -60,7 +60,6 @@ Security updates are provided for the following versions:
 - **Use environment variables**: Pass secrets via environment variables or mounted files
 - **Use secret management systems**
 - **Encrypt at rest**: Ensure Kubernetes Secrets are encrypted at rest
-
 
 #### 3. Route Configuration Security
 
@@ -202,7 +201,7 @@ By default, gRPC communication is not be encrypted:
 
 ## Security Contacts
 
-- **General security inquiries**: contact@wanaku.ai
+- **General security inquiries**: <contact@wanaku.ai>
 
 ## Security Resources
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,9 +4,9 @@ This document describes the architecture and design decisions for the Camel Inte
 
 ## System Overview
 
-The Camel Integration Capability acts as a bridge between AI agents and enterprise integration systems. 
+The Camel Integration Capability acts as a bridge between AI agents and enterprise integration systems.
 
-It dynamically loads Apache Camel routes and exposes them as MCP (Model Context Protocol) tools and resources through Wanaku's gRPC bridge, 
+It dynamically loads Apache Camel routes and exposes them as MCP (Model Context Protocol) tools and resources through Wanaku's gRPC bridge,
 enabling AI agents to interact with backend systems in a controlled, secure manner.
 
 ### High-Level Architecture
@@ -222,12 +222,14 @@ sequenceDiagram
 **Decision**: Load Camel routes dynamically from YAML at runtime instead of compile-time route builders.
 
 **Rationale**:
+
 - Allows non-developers to create integrations
 - Routes can be updated without recompiling/redeploying
 - Supports external route storage (DataStore, Git)
 - Enables visual route design tools (Kaoto)
 
 **Trade-offs**:
+
 - Runtime errors instead of compile-time validation
 - Slightly slower startup time
 - Requires careful YAML schema validation
@@ -237,6 +239,7 @@ sequenceDiagram
 **Decision**: Use gRPC instead of REST for communication with Wanaku router.
 
 **Rationale**:
+
 - Efficient binary protocol reduces latency
 - Built-in streaming support for future enhancements
 - Strong typing via Protocol Buffers
@@ -248,6 +251,7 @@ sequenceDiagram
 **Decision**: Use OAuth2 client credentials flow for service-to-service authentication.
 
 **Rationale**:
+
 - Industry-standard authentication mechanism
 - Centralized token management
 - Support for token refresh
@@ -258,6 +262,7 @@ sequenceDiagram
 **Decision**: Support both `datastore://` and `file://` schemes for resource loading.
 
 **Rationale**:
+
 - `datastore://` enables centralized configuration management
 - `file://` supports local development and air-gapped deployments
 - Extensible design allows future schemes (e.g., `git://`, `http://`)
@@ -267,6 +272,7 @@ sequenceDiagram
 **Decision**: Implement explicit rules for exposing routes as MCP tools/resources.
 
 **Rationale**:
+
 - Security: Not all routes should be exposed to AI agents
 - Flexibility: Same route can be exposed as tool or resource
 - Access control: Restrict certain operations or data
@@ -277,12 +283,14 @@ sequenceDiagram
 **Decision**: Download Maven dependencies at runtime instead of bundling everything.
 
 **Rationale**:
+
 - Smaller container images (base image + minimal JARs)
 - Flexibility to use different Camel components per deployment
 - Reduces build time and artifact size
 - Supports dynamic component loading
 
 **Trade-offs**:
+
 - Slower first startup (dependency download)
 - Requires network access at startup
 - Potential version conflicts if not carefully managed
@@ -292,6 +300,7 @@ sequenceDiagram
 **Decision**: Support both automatic and explicit parameter-to-header mapping strategies.
 
 **Rationale**:
+
 - **Automatic mapping** (default): All MCP parameters automatically map to Camel headers with `Wanaku.` prefix
   - Simplifies development and prototyping
   - No configuration needed for basic use cases
@@ -302,12 +311,15 @@ sequenceDiagram
   - Security through parameter filtering
 
 **Implementation**:
+
 The `HeaderMapperFactory` selects the appropriate mapper:
+
 - `NoopHeaderMapper`: When tool definition is null (no headers)
 - `AutoMapper`: When properties are not defined (all parameters with `Wanaku.` prefix)
 - `FilteredMapper`: When properties with mappings are defined (explicit control)
 
 **Trade-offs**:
+
 - Automatic mapping is convenient but requires `Wanaku.` prefix in routes
 - Explicit mapping is more verbose but provides better control and documentation
 - Users must choose one strategy per tool (mixing is not supported)
@@ -556,4 +568,3 @@ Potential areas for improvement:
 6. **Async Execution**: Non-blocking route execution with callbacks
 7. **Schema Validation**: Stronger input/output schema validation
 8. **Metrics & Monitoring**: Prometheus, Grafana dashboards
-

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -16,7 +16,7 @@ Since version 0.1.0, authentication is **optional**. When the Wanaku MCP Router 
 The service follows this authentication sequence at startup:
 
 1. **Initialization**: Service reads `--client-id` and `--client-secret` from CLI arguments or environment variables
-2. **Token Endpoint Resolution**: 
+2. **Token Endpoint Resolution**:
    - If `--token-endpoint` is provided, use it directly
    - Otherwise, auto-resolve from `--registration-url` (works with standard OAuth2 discovery endpoints)
 3. **Token Request**: Service requests an access token using client credentials
@@ -41,6 +41,7 @@ The service follows this authentication sequence at startup:
 ### Command-Line Examples
 
 **With authentication (Keycloak):**
+
 ```bash
 java -jar camel-integration-capability-main.jar \
   --client-id my-service \
@@ -50,6 +51,7 @@ java -jar camel-integration-capability-main.jar \
 ```
 
 **Without authentication:**
+
 ```bash
 java -jar camel-integration-capability-main.jar \
   --client-id my-service \
@@ -57,6 +59,7 @@ java -jar camel-integration-capability-main.jar \
 ```
 
 **Auto-resolve token endpoint:**
+
 ```bash
 java -jar camel-integration-capability-main.jar \
   --client-id my-service \
@@ -73,11 +76,13 @@ When using Keycloak as your OAuth2 provider, there are specific configuration re
 The `--token-endpoint` parameter must include the full realm path. The service will automatically append the OIDC protocol path.
 
 **Structure:**
-```
+
+```text
 --token-endpoint http://<keycloak-host>:<port>/realms/<realm-name>/
 ```
 
 **Examples:**
+
 ```bash
 # Production realm
 --token-endpoint http://keycloak:8543/realms/production/
@@ -90,12 +95,14 @@ The `--token-endpoint` parameter must include the full realm path. The service w
 ```
 
 The service resolves the complete token endpoint as:
-```
+
+```text
 <base-url>/protocol/openid-connect/token
 ```
 
 For example, `http://keycloak:8543/realms/my-realm/` becomes:
-```
+
+```text
 http://keycloak:8543/realms/my-realm/protocol/openid-connect/token
 ```
 
@@ -133,15 +140,18 @@ To create an OAuth2 client for the Camel Integration Capability:
 Since version 0.1.0, you can run the capability without OAuth2 authentication when the Wanaku MCP Router is configured to allow unauthenticated access.
 
 **When to disable authentication:**
+
 - Local development environments
 - Proof-of-concept deployments
 - Isolated networks where authentication is handled at the infrastructure level
 
 **How to disable:**
+
 - Omit the `--client-secret` parameter (or `CLIENT_SECRET` environment variable)
 - The `--client-id` parameter is still **required** — it serves as the service identifier in registration requests
 
 **Example:**
+
 ```bash
 java -jar camel-integration-capability-main.jar \
   --client-id employee-system \
@@ -149,6 +159,7 @@ java -jar camel-integration-capability-main.jar \
 ```
 
 **Security considerations:**
+
 - Only disable authentication in trusted environments
 - Never expose unauthenticated services to the public internet
 - Use network-level security (firewalls, VPCs) when authentication is disabled
@@ -164,6 +175,7 @@ All CLI parameters can be provided via environment variables. This is the recomm
 | `--token-endpoint` | `TOKEN_ENDPOINT` | `export TOKEN_ENDPOINT=http://keycloak:8543/realms/prod/` |
 
 **Shell example:**
+
 ```bash
 export CLIENT_ID=camel-integration-capability
 export CLIENT_SECRET=abc123def456
@@ -230,6 +242,7 @@ spec:
 ```
 
 **Security best practices:**
+
 - Never commit secrets to version control
 - Use RBAC to restrict access to the `wanaku-credentials` secret
 - Rotate credentials regularly
@@ -242,10 +255,12 @@ spec:
 **Symptom:** Service fails to start with an error about token endpoint resolution.
 
 **Causes:**
+
 1. `--token-endpoint` not provided and auto-resolution failed
 2. `--registration-url` does not support OAuth2 discovery
 
 **Solutions:**
+
 - Explicitly set `--token-endpoint` with the full realm path (for Keycloak)
 - Verify the registration URL is correct
 - Check network connectivity to the authentication server
@@ -255,12 +270,14 @@ spec:
 **Symptom:** Service fails to register or fetch resources with HTTP 401 errors.
 
 **Causes:**
+
 1. Invalid client credentials
 2. Client not properly configured in OAuth2 provider
 3. Service account roles not assigned
 4. Token expired (unlikely during startup)
 
 **Solutions:**
+
 - Verify `--client-id` matches the client ID in Keycloak/OAuth2 provider
 - Verify `--client-secret` matches the credential in the Credentials tab
 - Check that "Client authentication" is ON in Keycloak
@@ -273,12 +290,14 @@ spec:
 **Symptom:** Service cannot connect to the token endpoint.
 
 **Causes:**
+
 1. Token endpoint URL is incorrect
 2. Authentication server is not running
 3. Network connectivity issues
 4. Firewall blocking the connection
 
 **Solutions:**
+
 - Verify the token endpoint URL format (must include realm for Keycloak)
 - Check that Keycloak/OAuth2 server is running: `curl http://keycloak:8543/realms/my-realm/`
 - Test network connectivity from the capability container/pod
@@ -289,10 +308,12 @@ spec:
 **Symptom:** Token endpoint returns 404 or "Realm does not exist" error.
 
 **Causes:**
+
 1. Realm name is misspelled in `--token-endpoint`
 2. Realm does not exist in Keycloak
 
 **Solutions:**
+
 - Verify the realm name in Keycloak admin console
 - Check the URL format: `http://keycloak:8543/realms/<realm-name>/`
 - Realm names are case-sensitive
@@ -305,6 +326,7 @@ spec:
 **Cause:** The `--token-endpoint` parameter is missing the `/realms/<realm-name>/` path.
 
 **Solution:**
+
 ```bash
 # Wrong
 --token-endpoint http://keycloak:8543
@@ -353,6 +375,7 @@ The capability supports any OAuth2 provider that implements the client credentia
 - **Custom OAuth2 servers**
 
 **Requirements:**
+
 1. OAuth2 provider must support client credentials grant type
 2. Token endpoint must return a standard access token response
 3. Bearer token must be accepted by the Wanaku MCP Router
@@ -370,6 +393,7 @@ Token refresh is handled automatically by the Wanaku SDK:
 For deployments across multiple environments (dev, staging, production), use separate Keycloak realms and clients:
 
 **Development:**
+
 ```bash
 --client-id camel-capability-dev
 --client-secret dev-secret
@@ -377,6 +401,7 @@ For deployments across multiple environments (dev, staging, production), use sep
 ```
 
 **Production:**
+
 ```bash
 --client-id camel-capability-prod
 --client-secret prod-secret
@@ -384,6 +409,7 @@ For deployments across multiple environments (dev, staging, production), use sep
 ```
 
 This isolation ensures:
+
 - Separate credentials per environment
 - Different role assignments
 - Independent audit logs

--- a/docs/building.md
+++ b/docs/building.md
@@ -2,14 +2,14 @@
 
 ## Prerequisites
 
-* Java 21 or higher
-* [Apache Maven](https://maven.apache.org) 3.x is required to build and package the project.
+- Java 21 or higher
+- [Apache Maven](https://maven.apache.org) 3.x is required to build and package the project.
 
 ## Project Structure
 
 This is a multi-module Maven project:
 
-```
+```text
 pom.xml                                    # Parent aggregator
 ├── camel-integration-capability-common/   # Shared library
 ├── camel-integration-capability-runtimes/

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -40,6 +40,7 @@ Control how the service registers with the Wanaku MCP Router.
 ```
 
 This configuration:
+
 - Registers with the router at `http://wanaku-router:8080`
 - Tells the router to call back at `my-service.example.com:9190`
 - Identifies itself as `employee-integration`
@@ -59,7 +60,7 @@ OAuth2/OIDC credentials for authenticating with Wanaku services.
 
 If `--token-endpoint` is omitted, the service derives it from `--registration-url`:
 
-```
+```text
 --registration-url http://wanaku-router:8080
 → token endpoint: http://wanaku-router:8080/protocol/openid-connect/token
 ```
@@ -70,7 +71,7 @@ This works if Wanaku and the OAuth2 provider share the same base URL. For separa
 
 For Keycloak, the token endpoint format is:
 
-```
+```text
 http://<keycloak-host>:<port>/realms/<realm-name>/protocol/openid-connect/token
 ```
 
@@ -81,6 +82,7 @@ The service appends `/protocol/openid-connect/token`, so provide:
 ```
 
 **Wrong**:
+
 ```bash
 --token-endpoint http://keycloak:8543/
 ```
@@ -122,6 +124,7 @@ Control how the service loads routes, rules, and dependencies.
 ```
 
 The service will:
+
 1. Download `employee-system-v2.zip` from Wanaku's DataStore after registration
 2. Extract the catalog's `index.properties`
 3. Locate the `employee-system` resources within the catalog
@@ -173,18 +176,21 @@ Dependencies will be downloaded from these repositories in addition to Maven Cen
 `--service-catalog` is mutually exclusive with `--routes-ref`, `--rules-ref`, and `--dependencies`. You must choose one mode:
 
 **Catalog mode**:
+
 ```bash
 --service-catalog my-catalog \
 --service-catalog-system my-system
 ```
 
 **Individual files mode**:
+
 ```bash
 --routes-ref datastore://routes.camel.yaml \
 --rules-ref datastore://rules.yaml
 ```
 
 **Invalid (mixing modes)**:
+
 ```bash
 --service-catalog my-catalog \
 --service-catalog-system my-system \
@@ -379,25 +385,25 @@ The service validates parameters at startup. Common validation errors:
 
 **Missing required parameters**:
 
-```
+```text
 Missing required option: '--registration-url=<registrationUrl>'
 ```
 
 **Mutually exclusive parameters**:
 
-```
+```text
 --service-catalog is mutually exclusive with --routes-ref, --rules-ref, and --dependencies
 ```
 
 **Service catalog without system**:
 
-```
+```text
 --service-catalog-system is required when --service-catalog is used
 ```
 
 **Routes reference missing (individual file mode)**:
 
-```
+```text
 Either --routes-ref or --service-catalog must be provided
 ```
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -11,6 +11,7 @@ Version 0.1.0 introduces significant architectural changes, particularly around 
 The project was split into multiple Maven modules. This affects Maven coordinates and artifact selection.
 
 **Before (0.0.9):**
+
 ```xml
 <dependency>
     <groupId>ai.wanaku</groupId>
@@ -24,6 +25,7 @@ The project was split into multiple Maven modules. This affects Maven coordinate
 Choose the appropriate module based on your use case:
 
 **Standalone CLI application:**
+
 ```xml
 <dependency>
     <groupId>ai.wanaku</groupId>
@@ -33,6 +35,7 @@ Choose the appropriate module based on your use case:
 ```
 
 **SPI plugin for existing Camel apps:**
+
 ```xml
 <dependency>
     <groupId>ai.wanaku</groupId>
@@ -42,6 +45,7 @@ Choose the appropriate module based on your use case:
 ```
 
 **Shared library/common utilities:**
+
 ```xml
 <dependency>
     <groupId>ai.wanaku</groupId>
@@ -51,6 +55,7 @@ Choose the appropriate module based on your use case:
 ```
 
 The JAR file names also changed:
+
 - Main: `camel-integration-capability-main-0.1.0-jar-with-dependencies.jar`
 - Plugin: `camel-integration-capability-plugin-0.1.0-shaded.jar`
 
@@ -59,6 +64,7 @@ The JAR file names also changed:
 The Wanaku Capabilities SDK was upgraded from 0.0.x to 0.1.0. This introduces breaking changes in registration APIs.
 
 **Impact:**
+
 - Internal registration logic updated to use new SDK APIs
 - No action required for CLI users
 - Plugin users: ensure your Camel app uses compatible SDK versions
@@ -68,6 +74,7 @@ The Wanaku Capabilities SDK was upgraded from 0.0.x to 0.1.0. This introduces br
 Version 0.1.0 introduces **service catalogs** as the preferred way to package and distribute routes, rules, and dependencies.
 
 **Before (0.0.9):** Individual file references
+
 ```bash
 java -jar camel-integration-capability.jar \
   --routes-ref file:///path/to/routes.yaml \
@@ -76,6 +83,7 @@ java -jar camel-integration-capability.jar \
 ```
 
 **After (0.1.0):** Service catalog
+
 ```bash
 java -jar camel-integration-capability-main-*-jar-with-dependencies.jar \
   --service-catalog employee-system-v2 \
@@ -87,7 +95,8 @@ Individual file references (`--routes-ref`, `--rules-ref`, `--dependencies`) are
 **Creating a service catalog:**
 
 1. Create a directory structure:
-   ```
+
+   ```text
    my-catalog/
    ├── index.properties
    └── employee-system/
@@ -97,6 +106,7 @@ Individual file references (`--routes-ref`, `--rules-ref`, `--dependencies`) are
    ```
 
 2. Define `index.properties`:
+
    ```properties
    catalog.name=my-catalog-v1
    catalog.services=employee-system
@@ -106,6 +116,7 @@ Individual file references (`--routes-ref`, `--rules-ref`, `--dependencies`) are
    ```
 
 3. Package as a ZIP:
+
    ```bash
    cd my-catalog && zip -r my-catalog-v1.zip *
    ```
@@ -119,6 +130,7 @@ See the [examples/service-catalog](../examples/service-catalog) directory for a 
 The `--client-secret` parameter is now **optional**. Authentication can be disabled in the Wanaku MCP Router.
 
 **Before (0.0.9):** Always required
+
 ```bash
 java -jar camel-integration-capability.jar \
   --client-id wanaku-service \
@@ -126,6 +138,7 @@ java -jar camel-integration-capability.jar \
 ```
 
 **After (0.1.0):** Optional
+
 ```bash
 # With authentication
 java -jar camel-integration-capability-main-*-jar-with-dependencies.jar \
@@ -142,11 +155,13 @@ java -jar camel-integration-capability-main-*-jar-with-dependencies.jar \
 Version 0.1.0 adds gRPC health check support. The gRPC server now starts **before** registration to ensure health probes succeed.
 
 **Impact:**
+
 - Kubernetes/OpenShift deployments can now use gRPC health probes
 - No configuration changes required
 - Health endpoint: gRPC Health Checking Protocol on the gRPC port
 
 **Example Kubernetes health probe:**
+
 ```yaml
 livenessProbe:
   grpc:
@@ -160,6 +175,7 @@ livenessProbe:
 Version 0.1.0 introduces configurable route loading error handling.
 
 **Behavior:**
+
 - **Fail-fast (default):** Application exits if any route fails to load
 - **Log-and-continue:** Logs errors but continues with remaining routes
 
@@ -173,11 +189,13 @@ Set via environment variable or system property (exact mechanism depends on depl
 The Docker image entry point was updated to use the new JAR name:
 
 **Before (0.0.9):**
+
 ```dockerfile
 ENTRYPOINT ["java", "-jar", "camel-integration-capability.jar"]
 ```
 
 **After (0.1.0):**
+
 ```dockerfile
 ENTRYPOINT ["java", "-jar", "camel-integration-capability-main.jar"]
 ```

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -53,7 +53,7 @@ spec:
   - `initialDelaySeconds: 15` — Allow time for Camel context initialization
   - `periodSeconds: 10` — Check every 10 seconds
   - `failureThreshold: 3` — Restart after 3 consecutive failures (30 seconds)
-  
+
 - **Readiness Probe:**
   - `initialDelaySeconds: 10` — Routes should be loaded by this point
   - `periodSeconds: 5` — Check frequently for traffic routing decisions
@@ -139,6 +139,7 @@ Understanding startup phases helps tune health check timings and troubleshoot sl
 **Duration:** 30-60 seconds
 
 **Phases:**
+
 1. JVM initialization (2-5 seconds)
 2. Dependency download from Maven Central (20-40 seconds)
 3. Camel context creation (3-5 seconds)
@@ -147,6 +148,7 @@ Understanding startup phases helps tune health check timings and troubleshoot sl
 6. Service registration with Wanaku Router (1-3 seconds)
 
 **Optimization:**
+
 - Pre-populate `/data` volume with downloaded dependencies
 - Use a Maven mirror or repository manager (Nexus, Artifactory) closer to your deployment
 - Build a custom container image with dependencies pre-installed (trade-off: larger image size)
@@ -156,6 +158,7 @@ Understanding startup phases helps tune health check timings and troubleshoot sl
 **Duration:** 10-20 seconds
 
 **Phases:**
+
 1. JVM initialization (2-5 seconds)
 2. Dependency validation (1-2 seconds)
 3. Camel context creation (3-5 seconds)
@@ -164,6 +167,7 @@ Understanding startup phases helps tune health check timings and troubleshoot sl
 6. Service registration (1-3 seconds)
 
 **When this happens:**
+
 - Dependencies are already present in `/data`
 - Pod restart or rolling update with persistent volume
 - Horizontal scale-out with shared storage
@@ -171,15 +175,18 @@ Understanding startup phases helps tune health check timings and troubleshoot sl
 ### Runtime Performance
 
 **Route Execution Overhead:**
+
 - Apache Camel ProducerTemplate: sub-millisecond overhead
 - Actual route performance depends on backend system latency
 
 **gRPC Invocation Overhead:**
+
 - Serialization/deserialization: 1-3ms
 - Network latency (same cluster): 1-2ms
 - Total gRPC overhead: 1-5ms per invocation
 
 **Authentication Overhead:**
+
 - Token is cached after first retrieval
 - Per-request overhead: negligible (token included in headers)
 - Token refresh: occurs in background before expiration
@@ -191,6 +198,7 @@ The capability uses **SLF4J** with **Log4j2** as the logging backend.
 ### Configuration Files
 
 Log4j2 can be configured using either format:
+
 - `log4j2.properties` (simple key-value format)
 - `log4j2.xml` (full XML configuration)
 
@@ -215,6 +223,7 @@ java -Dlog4j2.configurationFile=/path/to/log4j2.xml \
 ### Setting Log Levels
 
 **Via log4j2.properties:**
+
 ```properties
 # Root logger
 rootLogger.level = info
@@ -236,12 +245,14 @@ logger.grpc.level = warn
 ```
 
 **Via environment variable (overrides config file):**
+
 ```bash
 export LOG_LEVEL=DEBUG
 java -jar camel-integration-capability-main.jar
 ```
 
 **Via system property:**
+
 ```bash
 java -Dlog4j2.rootLogger.level=DEBUG \
   -jar camel-integration-capability-main.jar
@@ -252,6 +263,7 @@ java -Dlog4j2.rootLogger.level=DEBUG \
 For production deployments, use JSON-formatted logs for easier parsing and analysis:
 
 **log4j2.xml example:**
+
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
@@ -274,6 +286,7 @@ For production deployments, use JSON-formatted logs for easier parsing and analy
 ```
 
 **Kubernetes ConfigMap for Log4j2:**
+
 ```yaml
 apiVersion: v1
 kind: ConfigMap
@@ -297,6 +310,7 @@ data:
 ```
 
 Mount as a volume:
+
 ```yaml
 volumeMounts:
   - name: logging-config
@@ -358,11 +372,13 @@ For local development or stable clusters where services start quickly:
 ### Registration Failure Scenarios
 
 If registration fails after all retries, the service will:
+
 1. Log an error message with the failure reason
 2. Exit with a non-zero status code
 3. Kubernetes will restart the pod (if using a Deployment)
 
 **Common Failure Reasons:**
+
 - Wanaku MCP Router is not accessible (check networking)
 - Authentication failed (check credentials)
 - Invalid registration request (check configuration)
@@ -374,12 +390,14 @@ The capability is **stateless** and designed for horizontal scaling.
 ### Horizontal Scaling
 
 **Characteristics:**
+
 - No shared state between instances
 - Each instance registers independently with the Wanaku MCP Router
 - Load balancing is handled by the Wanaku MCP Router
 - Instances can be added or removed dynamically
 
 **Kubernetes Deployment:**
+
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -434,11 +452,13 @@ spec:
 If routes are CPU or memory intensive, consider vertical scaling (increase resources per pod) instead of horizontal scaling.
 
 **When to use:**
+
 - Routes perform heavy computation
 - Large dependency graphs
 - Memory-intensive transformations
 
 **How to scale:**
+
 1. Increase CPU and memory limits in the Deployment
 2. Monitor actual usage with metrics
 3. Adjust based on observed patterns
@@ -448,6 +468,7 @@ If routes are CPU or memory intensive, consider vertical scaling (increase resou
 The Wanaku MCP Router distributes tool invocations across registered capability instances. No configuration is needed on the capability side.
 
 **Load Balancing Strategy:**
+
 - Determined by the Wanaku MCP Router
 - Typically round-robin or least-connections
 - Check Wanaku documentation for details
@@ -463,6 +484,7 @@ FROM registry.access.redhat.com/ubi9/openjdk-21:1.21
 ```
 
 **Why UBI9?**
+
 - Regularly updated with security patches
 - Minimal attack surface
 - Supported by Red Hat
@@ -471,6 +493,7 @@ FROM registry.access.redhat.com/ubi9/openjdk-21:1.21
 ### Data Directory
 
 The capability uses `/data` as the default directory for:
+
 - Downloaded Maven dependencies
 - Temporary files
 - Route cache
@@ -490,6 +513,7 @@ volumes:
 ```
 
 **PersistentVolumeClaim:**
+
 ```yaml
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -546,6 +570,7 @@ env:
 ```
 
 **Best practices:**
+
 - Create secrets via `kubectl create secret` (not in YAML)
 - Rotate credentials regularly
 - Use external secret managers (Vault, AWS Secrets Manager, etc.) for enterprise deployments
@@ -588,11 +613,13 @@ Currently, the capability does not expose Prometheus metrics or OpenTelemetry tr
 ### Current Observability
 
 **Logs:**
+
 - Structured JSON logs (via Log4j2)
 - Kubernetes log aggregation (Fluentd, Fluent Bit, etc.)
 - Centralized logging (Elasticsearch, Loki, CloudWatch)
 
 **Kubernetes Metrics:**
+
 - CPU and memory usage (via metrics-server)
 - Pod restarts and health check failures
 - Network traffic (service mesh metrics if using Istio, Linkerd, etc.)
@@ -602,6 +629,7 @@ Currently, the capability does not expose Prometheus metrics or OpenTelemetry tr
 Planned enhancements:
 
 **Prometheus Metrics:**
+
 - Route execution times
 - Error rates per route
 - gRPC request/response times
@@ -609,12 +637,14 @@ Planned enhancements:
 - Registration success/failure counts
 
 **OpenTelemetry Tracing:**
+
 - Distributed tracing across Wanaku services
 - Per-route execution spans
 - Correlation with backend system traces
 - Integration with Jaeger, Zipkin, or cloud tracing services
 
 **Health Metrics:**
+
 - Camel context status
 - Route health (up/down)
 - Dependency resolution failures
@@ -622,11 +652,13 @@ Planned enhancements:
 Until these are implemented, use the following approaches:
 
 **Application Performance Monitoring (APM):**
+
 - Attach APM agents (Datadog, New Relic, Elastic APM) to the JVM
 - Configure via `-javaagent` flag
 - Monitor JVM metrics, garbage collection, and thread pools
 
 **Custom Metrics via Routes:**
+
 - Use Camel's built-in metrics components (`camel-micrometer`, `camel-metrics`)
 - Export metrics from within routes
 - Aggregate in Prometheus or a time-series database
@@ -636,11 +668,13 @@ Until these are implemented, use the following approaches:
 ### Service Won't Start
 
 **Check logs:**
+
 ```bash
 kubectl logs -f deployment/camel-integration-capability
 ```
 
 **Common causes:**
+
 1. Missing required parameters (e.g., `--registration-url`)
 2. Authentication failure (invalid credentials)
 3. Cannot download routes or dependencies
@@ -648,6 +682,7 @@ kubectl logs -f deployment/camel-integration-capability
 5. Insufficient memory or disk space
 
 **Solutions:**
+
 - Verify all required CLI arguments are provided
 - Check authentication configuration (see [Authentication](authentication.md))
 - Verify network connectivity to DataStore and Maven Central
@@ -656,16 +691,19 @@ kubectl logs -f deployment/camel-integration-capability
 ### Registration Failures
 
 **Symptoms:**
+
 - Service starts but never registers with Wanaku Router
 - Logs show repeated registration attempts
 
 **Check:**
+
 1. Wanaku Router is running and accessible
 2. `--registration-url` is correct
 3. Authentication is configured correctly
 4. Network policies allow egress to the router
 
 **Increase retry parameters:**
+
 ```bash
 --initial-delay 30 \
 --retries 30 \
@@ -675,16 +713,19 @@ kubectl logs -f deployment/camel-integration-capability
 ### Route Execution Errors
 
 **Symptoms:**
+
 - Tool invocations return errors
 - Routes fail to execute
 
 **Check:**
+
 1. Route YAML syntax is valid
 2. Required Camel components are listed in dependencies
 3. Backend systems are accessible
 4. Credentials for backend systems are correct
 
 **Enable debug logging:**
+
 ```bash
 export LOG_LEVEL=DEBUG
 ```
@@ -692,15 +733,18 @@ export LOG_LEVEL=DEBUG
 ### High Memory Usage
 
 **Symptoms:**
+
 - Pods restarted due to OOMKilled
 - Memory usage grows over time
 
 **Causes:**
+
 1. Too many routes loaded
 2. Large dependencies (e.g., heavy XML processing libraries)
 3. Memory leak in custom routes
 
 **Solutions:**
+
 - Increase memory limits
 - Reduce number of routes per instance
 - Review route logic for memory leaks
@@ -709,15 +753,18 @@ export LOG_LEVEL=DEBUG
 ### Slow Startup
 
 **Symptoms:**
+
 - Health checks fail before service is ready
 - Startup takes longer than expected
 
 **Causes:**
+
 1. Slow dependency download (network latency to Maven Central)
 2. Many dependencies to download
 3. Large route files
 
 **Solutions:**
+
 - Use a Maven mirror closer to your deployment
 - Pre-populate `/data` volume with dependencies
 - Increase `initialDelaySeconds` in health checks
@@ -728,6 +775,7 @@ export LOG_LEVEL=DEBUG
 ### What to Back Up
 
 **Configuration:**
+
 - Route YAML files
 - Rule YAML files
 - Dependency declarations
@@ -735,11 +783,13 @@ export LOG_LEVEL=DEBUG
 - Log4j2 configuration
 
 **Secrets:**
+
 - OAuth2 client credentials
 - Backend system credentials
 - Certificates (if using mTLS)
 
 **Data Volume:**
+
 - Dependency cache in `/data` (optional — can be re-downloaded)
 
 ### Disaster Recovery
@@ -753,6 +803,7 @@ export LOG_LEVEL=DEBUG
 5. **Verification**: Check logs and health probes
 
 **Recovery Time Objective (RTO):**
+
 - Configuration restore: < 5 minutes
 - Service startup (cold): 30-60 seconds
 - Total RTO: < 10 minutes (assuming automation)
@@ -767,6 +818,7 @@ For mission-critical deployments:
 - Use PodDisruptionBudget to prevent simultaneous evictions
 
 **Pod Anti-Affinity Example:**
+
 ```yaml
 affinity:
   podAntiAffinity:
@@ -780,6 +832,7 @@ affinity:
 ```
 
 **PodDisruptionBudget:**
+
 ```yaml
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/docs/rules-schema.md
+++ b/docs/rules-schema.md
@@ -142,6 +142,7 @@ mcp:
 **Example**:
 
 Routes YAML:
+
 ```yaml
 - route:
     id: get-employee-route
@@ -153,6 +154,7 @@ Routes YAML:
 ```
 
 Rules YAML:
+
 ```yaml
 mcp:
   tools:
@@ -165,7 +167,7 @@ mcp:
 
 The tool is registered with Wanaku but invocations will fail with:
 
-```
+```text
 Route 'wrong-route-id' not found
 ```
 
@@ -855,7 +857,7 @@ mcp:
 
 If `route.id` doesn't match any loaded route:
 
-```
+```text
 ERROR Route 'unknown-route-id' not found
 ```
 
@@ -868,7 +870,7 @@ The tool is registered with Wanaku but invocations will fail. Verify:
 
 If a required field is missing:
 
-```
+```text
 ERROR Tool 'my-tool' is missing required field 'description'
 ```
 
@@ -878,7 +880,7 @@ Fix by adding the missing field.
 
 If the rules YAML is malformed:
 
-```
+```text
 ERROR Failed to parse rules file: expected <block end>, but found '<scalar>'
 ```
 
@@ -892,7 +894,7 @@ yamllint rules.yaml
 
 If a resource route has `autoStartup: true` (or defaults to true):
 
-```
+```text
 WARN Resource route 'my-resource-route' has auto-start enabled. This may cause unexpected behavior.
 ```
 
@@ -941,17 +943,20 @@ The service may log a warning but won't fail. However, the route will start cons
 Before deploying to production:
 
 1. **Validate YAML syntax**:
+
    ```bash
    yamllint rules.yaml
    ```
 
 2. **Check route IDs match**:
+
    ```bash
    grep "id:" routes.camel.yaml
    grep "id:" rules.yaml
    ```
 
 3. **Test with fail-fast enabled**:
+
    ```bash
    --fail-fast=true
    ```

--- a/docs/service-catalog-guide.md
+++ b/docs/service-catalog-guide.md
@@ -23,6 +23,7 @@ Service catalogs solve real operational headaches:
 **Simplified Configuration**: Compare these two deployment commands:
 
 **Without catalog** (three moving parts):
+
 ```bash
 --routes-ref datastore://routes.camel.yaml \
 --rules-ref datastore://rules.yaml \
@@ -30,6 +31,7 @@ Service catalogs solve real operational headaches:
 ```
 
 **With catalog** (one reference):
+
 ```bash
 --service-catalog employee-system-v2 \
 --service-catalog-system employee-system
@@ -43,7 +45,7 @@ A service catalog ZIP must contain an `index.properties` file at the root. This 
 
 ### Example Catalog Layout
 
-```
+```text
 employee-system-v2.zip
 ├── index.properties
 └── employee-system/
@@ -54,7 +56,7 @@ employee-system-v2.zip
 
 You can include multiple systems in one catalog:
 
-```
+```text
 hr-systems-v3.zip
 ├── index.properties
 ├── employee-system/
@@ -175,7 +177,7 @@ unzip -l employee-system-v2.zip
 
 Expected output:
 
-```
+```text
 Archive:  employee-system-v2.zip
   Length      Date    Time    Name
 ---------  ---------- -----   ----
@@ -372,12 +374,14 @@ Catalogs are the path from "it works on my machine" to "it works the same way ev
 **Check**:
 
 1. Verify the catalog exists in Wanaku's DataStore:
+
    ```bash
    curl -H "Authorization: Bearer $TOKEN" \
      http://wanaku-datastore:8080/api/v1/catalogs/employee-system-v2
    ```
 
 2. Verify the `catalog.name` in `index.properties` matches `--service-catalog`:
+
    ```bash
    unzip -p employee-system-v2.zip index.properties | grep catalog.name
    ```
@@ -388,6 +392,7 @@ Catalogs are the path from "it works on my machine" to "it works the same way ev
    - Verify `--client-id` and `--client-secret` are correct
 
 4. Check network connectivity:
+
    ```bash
    kubectl exec deployment/camel-integration-capability -- \
      curl -v http://wanaku-datastore:8080/health
@@ -402,11 +407,13 @@ Catalogs are the path from "it works on my machine" to "it works the same way ev
 **Fix**:
 
 1. List the available systems:
+
    ```bash
    unzip -p hr-systems-v3.zip index.properties | grep catalog.services
    ```
 
 2. Use the exact system name (case-sensitive):
+
    ```bash
    --service-catalog-system payroll-system
    ```
@@ -420,11 +427,13 @@ Catalogs are the path from "it works on my machine" to "it works the same way ev
 **Debug**:
 
 1. List the ZIP contents:
+
    ```bash
    unzip -l employee-system-v2.zip
    ```
 
 2. Compare to `index.properties`:
+
    ```bash
    unzip -p employee-system-v2.zip index.properties
    ```
@@ -449,6 +458,7 @@ unzip -p employee-system-v2.zip index.properties
 ```
 
 Check that:
+
 - `catalog.name` is present
 - `catalog.services` lists all systems
 - Each system has `catalog.routes.<system>` and `catalog.rules.<system>`
@@ -459,7 +469,7 @@ Large organizations often manage multiple related systems. Multi-system catalogs
 
 ### Example: HR Systems Catalog
 
-```
+```text
 hr-systems-v3.zip
 ├── index.properties
 ├── employee-system/

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -58,6 +58,7 @@ If the route file can't be found or downloaded, routes won't load.
 **For datastore:// URIs**:
 
 1. Verify the file exists in Wanaku's DataStore:
+
    ```bash
    curl -H "Authorization: Bearer $TOKEN" \
      http://wanaku-datastore:8080/api/v1/files/routes.camel.yaml
@@ -66,7 +67,8 @@ If the route file can't be found or downloaded, routes won't load.
 2. Check that OAuth2 authentication succeeded (DataStore requires a token).
 
 3. Look for download retry attempts in logs:
-   ```
+
+   ```text
    INFO  Attempting to download datastore://routes.camel.yaml (attempt 1/12)
    ERROR Failed to download routes.camel.yaml: 404 Not Found
    ```
@@ -74,6 +76,7 @@ If the route file can't be found or downloaded, routes won't load.
 **For file:// URIs**:
 
 1. Verify the path is absolute, not relative:
+
    ```bash
    # Wrong (relative path)
    --routes-ref file://routes.camel.yaml
@@ -83,6 +86,7 @@ If the route file can't be found or downloaded, routes won't load.
    ```
 
 2. Check file permissions:
+
    ```bash
    ls -la /tmp/routes.camel.yaml
    ```
@@ -90,6 +94,7 @@ If the route file can't be found or downloaded, routes won't load.
    The service must have read access. In Kubernetes, this often means the file is in a mounted ConfigMap or volume.
 
 3. In Kubernetes, exec into the pod and verify:
+
    ```bash
    kubectl exec deployment/camel-integration-capability -- ls -la /data/routes.camel.yaml
    ```
@@ -102,7 +107,7 @@ Routes that reference Camel components not in the base distribution will fail to
 
 **Example**:
 
-```
+```text
 ERROR Failed to create route: No component found with name 'http'
 ```
 
@@ -110,7 +115,7 @@ This means the route uses `camel-http` but it's not on the classpath.
 
 **Fix**: Provide a dependencies file:
 
-```
+```text
 org.apache.camel:camel-http:4.18.1
 ```
 
@@ -150,7 +155,7 @@ kubectl logs deployment/camel-integration-capability | grep "Started route"
 
 If you see:
 
-```
+```text
 INFO Started route-1 (direct://route-1)
 INFO Started route-2 (direct://route-2)
 ```
@@ -234,18 +239,20 @@ Check `--client-id` and `--client-secret` match the OAuth2 provider's configurat
 The `--token-endpoint` must point to the OAuth2/OIDC token endpoint. For Keycloak, **include the realm path**:
 
 **Wrong**:
+
 ```bash
 --token-endpoint http://keycloak:8543/
 ```
 
 **Correct**:
+
 ```bash
 --token-endpoint http://keycloak:8543/realms/my-realm/
 ```
 
 The service appends `/protocol/openid-connect/token` automatically, so the full URL becomes:
 
-```
+```text
 http://keycloak:8543/realms/my-realm/protocol/openid-connect/token
 ```
 
@@ -308,7 +315,7 @@ kubectl logs deployment/camel-integration-capability | grep -i "token\|refresh"
 
 Look for:
 
-```
+```text
 ERROR Failed to refresh OAuth2 token
 ERROR HTTP 401 Unauthorized when calling Wanaku API
 ```
@@ -334,13 +341,15 @@ kubectl rollout restart deployment/camel-integration-capability
 Dependencies must use the `groupId:artifactId:version` format:
 
 **Correct**:
-```
+
+```text
 org.apache.camel:camel-http:4.18.1
 com.mycompany:custom-beans:2.0.0
 ```
 
 **Wrong**:
-```
+
+```text
 camel-http:4.18.1              # Missing groupId
 org.apache.camel:camel-http    # Missing version
 ```
@@ -353,13 +362,13 @@ cat dependencies.txt
 
 Ensure it's comma-separated (or newline-separated):
 
-```
+```text
 org.apache.camel:camel-http:4.18.1,org.apache.camel:camel-jackson:4.18.1
 ```
 
 Or:
 
-```
+```text
 org.apache.camel:camel-http:4.18.1
 org.apache.camel:camel-jackson:4.18.1
 ```
@@ -402,7 +411,7 @@ kubectl logs deployment/camel-integration-capability | grep -i "download\|retry"
 
 You'll see:
 
-```
+```text
 INFO  Attempting to download org.apache.camel:camel-http:4.18.1 (attempt 1/12)
 WARN  Download failed, retrying in 5 seconds...
 INFO  Attempting to download org.apache.camel:camel-http:4.18.1 (attempt 2/12)
@@ -548,7 +557,7 @@ kubectl logs deployment/camel-integration-capability | grep -i "registration\|re
 
 You'll see:
 
-```
+```text
 INFO  Attempting to register with Wanaku (attempt 1/12)
 WARN  Registration failed: Connection refused
 INFO  Waiting 5 seconds before retry...
@@ -573,13 +582,13 @@ kubectl logs deployment/camel-integration-capability | grep -i "token\|oauth"
 
 Look for:
 
-```
+```text
 INFO  Acquired OAuth2 token successfully
 ```
 
 Or:
 
-```
+```text
 ERROR Failed to acquire OAuth2 token: invalid_client
 ```
 
@@ -597,13 +606,13 @@ kubectl logs deployment/camel-integration-capability | grep -i "grpc\|port\|bind
 
 Look for:
 
-```
+```text
 INFO  gRPC server started on port 9190
 ```
 
 Or:
 
-```
+```text
 ERROR Failed to bind to port 9190: Address already in use
 ```
 
@@ -648,7 +657,7 @@ kubectl exec deployment/wanaku-router -- \
 
 This should list the available gRPC services:
 
-```
+```text
 ai.wanaku.capability.grpc.CamelToolService
 ai.wanaku.capability.grpc.CamelResourceService
 ```
@@ -763,7 +772,7 @@ You can't mix `--service-catalog` with `--routes-ref`, `--rules-ref`, or `--depe
 
 **Error**:
 
-```
+```text
 --service-catalog is mutually exclusive with --routes-ref, --rules-ref, and --dependencies
 ```
 
@@ -779,7 +788,7 @@ kubectl logs deployment/camel-integration-capability | grep -i "catalog\|downloa
 
 You'll see:
 
-```
+```text
 INFO  Downloading service catalog 'employee-system-v2'
 WARN  Download failed, retrying in 5 seconds...
 INFO  Downloading service catalog 'employee-system-v2' (attempt 2/12)
@@ -889,7 +898,7 @@ spec:
 
 **Route loading**:
 
-```
+```text
 DEBUG WanakuRoutesLoader - Parsing routes from /data/routes.camel.yaml
 DEBUG WanakuRoutesLoader - Found 3 routes in YAML
 DEBUG WanakuRoutesLoader - Loading route 'get-employee-info'
@@ -898,7 +907,7 @@ DEBUG WanakuRoutesLoader - Route 'get-employee-info' started successfully
 
 **Dependency resolution**:
 
-```
+```text
 DEBUG DependencyDownloader - Downloading org.apache.camel:camel-http:4.18.1
 DEBUG DependencyDownloader - Resolved 12 transitive dependencies
 DEBUG DependencyDownloader - Downloaded camel-http-4.18.1.jar to /tmp/camel-deps/
@@ -906,7 +915,7 @@ DEBUG DependencyDownloader - Downloaded camel-http-4.18.1.jar to /tmp/camel-deps
 
 **Tool invocations**:
 
-```
+```text
 DEBUG CamelTool - Received invocation for tool 'get-employee-info'
 DEBUG CamelTool - Mapping parameter 'employeeId' to header 'Wanaku.employeeId'
 DEBUG CamelTool - Executing route 'get-employee-info'
@@ -915,7 +924,7 @@ DEBUG CamelTool - Route completed in 234ms
 
 **Registration**:
 
-```
+```text
 DEBUG ZeroDepRegistrationManager - Attempting registration (attempt 1/12)
 DEBUG ZeroDepRegistrationManager - Acquired OAuth2 token
 DEBUG ZeroDepRegistrationManager - Registration successful, service ID: camel-12345

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -3,17 +3,20 @@
 A capability service for the [Wanaku MCP Router](https://wanaku.ai) that provides [Apache Camel](https://camel.apache.org) route
 execution capabilities.
 
-This service integrates with the Wanaku ecosystem to execute Camel routes dynamically through Wanaku's gRPC bridge. 
+This service integrates with the Wanaku ecosystem to execute Camel routes dynamically through Wanaku's gRPC bridge.
 
 ## Overview
 
 This service implements a Wanaku capability that can:
+
 - Execute Apache Camel routes defined in YAML format
 - Register itself with a Wanaku discovery service
 - Support service-to-router authentication via OAuth2/OIDC
 
 > [TIP]
 > Design your Camel routes with ease using the [Kaoto Integration Designer](http://kaoto.io) for Apache Camel.
+
+<!-- -->
 
 > [NOTE]
 > Upgrading from a previous version? See the [Migration Guide](migration-guide.md) for breaking changes and upgrade steps.
@@ -41,8 +44,8 @@ This capability can be deployed in two ways:
 
 ## Running this Capability
 
-This capability service requires configuration parameters to connect to the Wanaku ecosystem. When launching it, you need to 
-set them so that this capability service can talk to Wanaku and register itself. 
+This capability service requires configuration parameters to connect to the Wanaku ecosystem. When launching it, you need to
+set them so that this capability service can talk to Wanaku and register itself.
 
 > [NOTE]
 > Although this capability is intended to be run inside Kubernetes or OpenShift, it is entirely possible to execute it locally.
@@ -133,9 +136,9 @@ org.apache.camel:camel-http:4.14.2,org.apache.camel:camel-jackson:4.14.2
 
 ## Deploying the Service
 
-The service can be deployed to Kubernetes or OpenShift using the Wanaku's operator. 
+The service can be deployed to Kubernetes or OpenShift using the Wanaku's operator.
 
-##### Using a Service Catalog (Recommended)
+### Using a Service Catalog (Recommended)
 
 ```yaml
 apiVersion: "wanaku.ai/v1alpha1"
@@ -164,7 +167,7 @@ spec:
           value: "employee-system"
 ```
 
-##### Using Individual References
+### Using Individual References
 
 ```yaml
 apiVersion: "wanaku.ai/v1alpha1"
@@ -216,12 +219,14 @@ spec:
 Common issues and solutions:
 
 **Routes not found:**
+
 ```bash
 # Verify git clone succeeded
 kubectl exec deployment/camel-integration-capability -- ls -la /data
 ```
 
 **Service not registering:**
+
 ```bash
 # Check environment variables
 kubectl exec deployment/camel-integration-capability -- env | grep -E "(REGISTRATION|TOKEN)"
@@ -231,6 +236,7 @@ kubectl logs -f deployment/camel-integration-capability -c camel-integration-cap
 ```
 
 **Connection refused errors:**
+
 ```bash
 # Verify service is running
 kubectl get svc camel-integration-capability
@@ -244,10 +250,10 @@ kubectl run test-pod --rm -it --image=busybox -- telnet camel-integration-capabi
 
 ## Designing Routes
 
-The easiest way to design the routes for this project, is to use a visual editor such as [Kaoto](http://kaoto.io) or 
-[Camel Karavan](http://camel.apache.org/karavan) to design the routes. 
+The easiest way to design the routes for this project, is to use a visual editor such as [Kaoto](http://kaoto.io) or
+[Camel Karavan](http://camel.apache.org/karavan) to design the routes.
 
-Those editors should allow you to visualize the route. For instance: 
+Those editors should allow you to visualize the route. For instance:
 
 ![Kaoto Route Example](imgs/kaoto.png)
 
@@ -330,7 +336,6 @@ the data MUST be convertable to a Java String.
 > [IMPORTANT]
 > Routes serving resources MUST have their auto-start disabled.
 
-
 #### Parameter to Header Mapping
 
 The capability automatically maps MCP tool parameters to Apache Camel headers. There are two mapping strategies:
@@ -384,7 +389,7 @@ The capability automatically creates these Camel headers:
 
 ##### Explicit Mapping (Filtered)
 
-When you define `properties` with `mapping` elements, only those explicitly mapped parameters are passed to the Camel route. 
+When you define `properties` with `mapping` elements, only those explicitly mapped parameters are passed to the Camel route.
 This provides fine-grained control over parameter names and validation.
 
 **Example tool definition with explicit mappings:**
@@ -474,37 +479,37 @@ The `mapping` element supports the following options:
    - To restrict which parameters are passed to backend systems
 3. **Never mix both**: Either define properties with mappings (explicit) OR omit properties entirely (automatic)
 
-### Handling Dependencies 
+### Handling Dependencies
 
-The capability only comes with a subset of the Apache Camel dependencies. 
-As such, when running it for the first time, the capability will automatically download the dependencies required for the 
-integration. 
+The capability only comes with a subset of the Apache Camel dependencies.
+As such, when running it for the first time, the capability will automatically download the dependencies required for the
+integration.
 
-However, external dependencies, such as those containing the beans for your integration, 
-will have to be provided externally. 
+However, external dependencies, such as those containing the beans for your integration,
+will have to be provided externally.
 You can do so by providing a list of external dependencies to download and store that list in a text file.
 The capability can automatically download and include on the classpath all these dependencies.
 
-For instance, to include the `com.mycompany:beans-app1:2.0.0` and `com.mycompany:beans-support:1.5.0` dependencies, you can create a text file 
+For instance, to include the `com.mycompany:beans-app1:2.0.0` and `com.mycompany:beans-support:1.5.0` dependencies, you can create a text file
 with the following contents:
 
-```
+```text
 com.mycompany:beans-app1:2.0.0,com.mycompany:beans-support:1.5.0
 ```
 
 Then publish it to Wanaku's Data Store (or, git, if using the git initializer) and refer to the file accordingly
 
-* `--dependencies datastore://filename.txt` if using the data store 
-* `--dependencies file:///path/to/filename.txt` if using the git initializer
+- `--dependencies datastore://filename.txt` if using the data store
+- `--dependencies file:///path/to/filename.txt` if using the git initializer
 
 > [NOTE]
-> Repositories for dependencies can be set using the `--repositories` option, which receives a comma-separate list of 
+> Repositories for dependencies can be set using the `--repositories` option, which receives a comma-separate list of
 > repository URLs.
 
 ## Running the Capability and Exposing Camel Routes
 
-After designing the routes, you will need to have the capability use them and expose them as MCP 
-tools or MCP resources. To do so, the capability needs to have access to the files. 
+After designing the routes, you will need to have the capability use them and expose them as MCP
+tools or MCP resources. To do so, the capability needs to have access to the files.
 
 Route files can be provided to the capability using one of the following methods:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -503,7 +503,7 @@ Then publish it to Wanaku's Data Store (or, git, if using the git initializer) a
 - `--dependencies file:///path/to/filename.txt` if using the git initializer
 
 > [NOTE]
-> Repositories for dependencies can be set using the `--repositories` option, which receives a comma-separate list of
+> Repositories for dependencies can be set using the `--repositories` option, which receives a comma-separated list of
 > repository URLs.
 
 ## Running the Capability and Exposing Camel Routes

--- a/examples/employee-system/README.md
+++ b/examples/employee-system/README.md
@@ -11,6 +11,7 @@ The example exposes three MCP tools that interact with a backend employee servic
 3. **get-employee-compensation**: Fetches current and historical pay details
 
 The routes demonstrate:
+
 - Explicit parameter mapping (MCP parameter names → Camel headers)
 - HTTP backend integration
 - Conditional logic (restricting executive data)
@@ -52,7 +53,7 @@ java -jar ../../camel-integration-capability-runtimes/camel-integration-capabili
 
 Once registered with Wanaku, AI agents can invoke the tools:
 
-```
+```text
 AI: Get employee information for employee ID 12345
 ```
 
@@ -65,6 +66,7 @@ Expected response: JSON containing employee profile data from the backend.
 Unlike the [hello-world example](../hello-world), this example uses **explicit parameter mapping** to control how MCP parameters map to Camel headers.
 
 In the rules file:
+
 ```yaml
 properties:
   - name: employeeId
@@ -79,6 +81,7 @@ properties:
 This maps the MCP parameter `employeeId` → Camel header `EMPLOYEE_ID`.
 
 The route accesses it via:
+
 ```yaml
 - toD:
     uri: http://employee-backend-service:8081/employee/${header.EMPLOYEE_ID}/information
@@ -88,7 +91,7 @@ The route accesses it via:
 
 The `employee-backend-dependencies.txt` file specifies additional Camel components to download at runtime:
 
-```
+```text
 org.apache.camel:camel-http:4.18.2
 ```
 
@@ -97,6 +100,7 @@ This allows routes to use the HTTP component without pre-packaging all possible 
 ### Multi-Step Routes
 
 The `get-employee-complete-profile` route demonstrates route orchestration:
+
 1. Calls `direct:employee-information`
 2. Stores the result in an exchange property
 3. Calls `direct:employee-reviews`
@@ -109,6 +113,7 @@ This shows how to compose complex workflows from simpler routes.
 ### Conditional Logic
 
 The `get-employee-information` route includes conditional logic:
+
 ```yaml
 - choice:
     when:

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -5,6 +5,7 @@ This is a minimal example demonstrating the basic functionality of the Camel Int
 ## What It Does
 
 The example exposes a single route that:
+
 1. Accepts a greeting message as input
 2. Logs it to the console
 3. Returns a formatted greeting response
@@ -40,12 +41,13 @@ java -jar ../../camel-integration-capability-runtimes/camel-integration-capabili
 
 Once registered with Wanaku, AI agents can invoke the `sends-greeting` tool:
 
-```
+```text
 AI: Send a greeting with message "World"
 ```
 
 Expected response:
-```
+
+```text
 Hello World from route-3104
 ```
 
@@ -56,6 +58,7 @@ Hello World from route-3104
 This example uses **automatic parameter mapping**. The MCP parameter `wanaku_body` is automatically mapped to the Camel message body because it follows the naming convention `wanaku_body`.
 
 The Camel route accesses it via `${body}`:
+
 ```yaml
 - log:
     message: Hello ${body}
@@ -64,6 +67,7 @@ The Camel route accesses it via `${body}`:
 ### Route Exposure
 
 The rules file defines which routes are exposed as MCP tools:
+
 ```yaml
 tools:
   - sends-greeting:

--- a/examples/service-catalog/README.md
+++ b/examples/service-catalog/README.md
@@ -5,12 +5,14 @@ This example demonstrates how to package routes, rules, and dependencies as a **
 ## What Is a Service Catalog?
 
 A service catalog is a versioned, self-contained archive (ZIP file) that bundles:
+
 - Camel routes
 - MCP tool/resource exposure rules
 - Maven dependencies
 - Metadata (catalog name, service names)
 
 Service catalogs provide:
+
 - **Version control**: Track catalog versions independently from the application
 - **Atomic deployment**: Deploy all related routes and rules together
 - **Simplified configuration**: Reference by name instead of individual file URLs
@@ -25,7 +27,7 @@ Service catalogs provide:
 
 ## Catalog Structure
 
-```
+```text
 employee-system-v2/
 ├── index.properties                      # Catalog metadata
 └── employee-system/                      # Service directory
@@ -54,6 +56,7 @@ catalog.dependencies.employee-system=employee-system/dependencies.txt
 ```
 
 **Key points:**
+
 - `catalog.name`: Unique identifier for this catalog version
 - `catalog.services`: List of service names (can be multiple, comma-separated)
 - For each service, specify routes, rules, and dependencies using `catalog.<type>.<service-name>=<path>`
@@ -69,6 +72,7 @@ mkdir -p my-catalog/my-service
 ### 2. Add Your Files
 
 Place routes, rules, and dependencies in the service directory:
+
 ```bash
 cp routes.camel.yaml my-catalog/my-service/
 cp rules.wanaku-rules.yaml my-catalog/my-service/
@@ -97,6 +101,7 @@ zip -r my-catalog-v1.zip *
 ### 5. Upload to DataStore or File Server
 
 Upload the ZIP file to:
+
 - Wanaku DataStore service
 - File server (accessible via HTTP/HTTPS)
 - Cloud storage (S3, GCS, Azure Blob)
@@ -117,6 +122,7 @@ java -jar camel-integration-capability-main-*-jar-with-dependencies.jar \
 ```
 
 The application will:
+
 1. Query the Wanaku DataStore for `employee-system-v2`
 2. Download and extract the catalog
 3. Load routes, rules, and dependencies for the `employee-system` service
@@ -170,6 +176,7 @@ catalog.dependencies.crm-system=crm-system/dependencies.txt
 ```
 
 Deploy a specific service:
+
 ```bash
 --service-catalog enterprise-integrations-v3 \
 --service-catalog-system inventory-system
@@ -208,7 +215,7 @@ java -jar ../../camel-integration-capability-runtimes/camel-integration-capabili
 
 ### 3. Test via AI Agent
 
-```
+```text
 AI: Get employee information for employee ID 12345
 ```
 


### PR DESCRIPTION
## Summary

- Add `markdownlint-cli2` configuration (`.markdownlint-cli2.yaml`) with pragmatic rule settings: disable line-length, inline HTML, table-column-style, and emphasis-as-heading rules; set dash list style
- Add GitHub Actions workflow (`.github/workflows/markdown-lint.yml`) that runs on PRs to `main` when documentation files change
- Fix all existing markdown violations across 18 files (~263 issues) so the CI gate passes from day one

## Test plan

- [x] Verify `npx markdownlint-cli2` exits with 0 locally
- [ ] Verify the new workflow triggers on a PR that modifies docs
- [ ] Spot-check rendered markdown in a few docs files for formatting regressions

## Summary by Sourcery

Add markdown linting configuration and CI, and update existing Markdown files to comply with the new rules.

Enhancements:
- Configure markdownlint-cli2 with project-appropriate rules and ignore patterns for docs and examples.
- Normalize and tidy Markdown formatting across documentation, examples, and project docs to satisfy linting rules without changing content.

CI:
- Introduce a GitHub Actions workflow to run markdownlint on Markdown and docs files for pull requests targeting main.