### PR TITLE
Fix #103: make --client-id optional when running without authentication

### DIFF
--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
@@ -132,16 +132,22 @@ public class CamelToolMain implements Callable<Integer> {
             required = false)
     private String tokenEndpoint;
 
-    @CommandLine.Option(
-            names = {"--client-id"},
-            description = "The client ID authentication",
-            required = true)
-    private String clientId;
+    static class AuthConfig {
+        @CommandLine.Option(
+                names = {"--client-id"},
+                description = "The client ID for authentication",
+                required = true)
+        String clientId;
 
-    @CommandLine.Option(
-            names = {"--client-secret"},
-            description = "The client secret authentication")
-    private String clientSecret;
+        @CommandLine.Option(
+                names = {"--client-secret"},
+                description = "The client secret for authentication",
+                required = true)
+        String clientSecret;
+    }
+
+    @CommandLine.ArgGroup(exclusive = false)
+    private AuthConfig authConfig;
 
     @CommandLine.Option(
             names = {"--no-wait"},
@@ -246,9 +252,9 @@ public class CamelToolMain implements Callable<Integer> {
         final ServiceConfig serviceConfig = DefaultServiceConfig.Builder.newBuilder()
                 .baseUrl(registrationUrl)
                 .serializer(new JacksonSerializer())
-                .clientId(clientId)
+                .clientId(authConfig != null ? authConfig.clientId : null)
                 .tokenEndpoint(TokenEndpoint.autoResolve(registrationUrl, tokenEndpoint))
-                .secret(clientSecret)
+                .secret(authConfig != null ? authConfig.clientSecret : null)
                 .build();
 
         final ServiceTarget serviceTarget = newServiceTargetTarget();

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -25,16 +25,11 @@ The service follows this authentication sequence at startup:
 
 ## Configuration Parameters
 
-### Required Parameters
+### Authentication Parameters
 
 | Parameter | Environment Variable | Description |
 |-----------|---------------------|-------------|
-| `--client-id` | `CLIENT_ID` | OAuth2 client ID for this capability. Required in all scenarios, even when authentication is disabled (used as service identifier) |
-
-### Optional Parameters
-
-| Parameter | Environment Variable | Description |
-|-----------|---------------------|-------------|
+| `--client-id` | `CLIENT_ID` | OAuth2 client ID. Required when `--client-secret` is provided. |
 | `--client-secret` | `CLIENT_SECRET` | OAuth2 client secret. Required only when the Wanaku MCP Router enforces authentication. Omit when authentication is disabled. |
 | `--token-endpoint` | `TOKEN_ENDPOINT` | Base URL for the OAuth2 token endpoint. If not specified, auto-resolved from `--registration-url`. For Keycloak, must include the realm path. |
 
@@ -54,7 +49,6 @@ java -jar camel-integration-capability-main.jar \
 
 ```bash
 java -jar camel-integration-capability-main.jar \
-  --client-id my-service \
   --registration-url http://wanaku-router:8080
 ```
 
@@ -147,14 +141,12 @@ Since version 0.1.0, you can run the capability without OAuth2 authentication wh
 
 **How to disable:**
 
-- Omit the `--client-secret` parameter (or `CLIENT_SECRET` environment variable)
-- The `--client-id` parameter is still **required** — it serves as the service identifier in registration requests
+- Omit both the `--client-secret` and `--client-id` parameters (or their environment variables)
 
 **Example:**
 
 ```bash
 java -jar camel-integration-capability-main.jar \
-  --client-id employee-system \
   --registration-url http://localhost:8080
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -54,8 +54,6 @@ set them so that this capability service can talk to Wanaku and register itself.
 
 - `--registration-url`: URL of the Wanaku discovery service
 - `--registration-announce-address`: Address to announce for service discovery
-- `--client-id`: OAuth2 client ID for authentication
-- `--client-secret`: OAuth2 client secret for authentication
 
 One of the following is required to provide routes:
 
@@ -64,6 +62,8 @@ One of the following is required to provide routes:
 
 ### Optional Parameters
 
+- `--client-id`: OAuth2 client ID for authentication. Required when `--client-secret` is provided.
+- `--client-secret`: OAuth2 client secret for authentication. When omitted, authentication is disabled.
 - `--service-catalog-system`: The system name within the service catalog (required when using `--service-catalog`)
 - `--token-endpoint`: OAuth2/OIDC token endpoint base URL. When pointing to a Keycloak instance, include the realm path (e.g., `http://keycloak:8543/realms/my-realm/`). The realm name is fully configurable — there is no default.
 - `--rules-ref`: Reference to the YAML file with route exposure rules. Supports `datastore://` and `file://` schemes


### PR DESCRIPTION
## Summary

- Removed `required = true` from the `--client-id` picocli option so the service can start without it when authentication is disabled
- Added validation in `validateOptions()` to enforce that `--client-id` is provided when `--client-secret` is set
- Updated `docs/authentication.md` and `docs/usage.md` to reflect the new behavior

## Test plan

- [x] Build passes (`mvn verify` — 12 tests, 0 failures)
- [ ] Run without `--client-id` and without `--client-secret` — service should start
- [ ] Run with `--client-secret` but without `--client-id` — should fail with a clear error message
- [ ] Run with both `--client-id` and `--client-secret` — should work as before

## Summary by Sourcery

Relax client authentication requirements so the service can run without a client ID when auth is disabled, while still enforcing a client ID when a client secret is configured.

Bug Fixes:
- Allow the service to start without specifying --client-id when authentication is disabled, while failing fast when --client-secret is provided without a client ID.

Enhancements:
- Clarify command-line help text for client authentication options.

Documentation:
- Update authentication and usage documentation to describe the new optional client ID behavior and provide aligned examples.