### PR TITLE
chore: use picocli ArgGroup for mutually dependent options

### DIFF
--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
@@ -140,23 +140,23 @@ public class CamelToolMain implements Callable<Integer> {
     @CommandLine.ArgGroup(exclusive = false)
     private RouteRefOptions routeRefOptions;
 
-    @CommandLine.Option(
-            names = {"--token-endpoint"},
-            description = "The base URL for the authentication",
-            required = false)
-    private String tokenEndpoint;
-
     static class AuthConfig {
         @CommandLine.Option(
+                names = {"--token-endpoint"},
+                required = true,
+                description = "The base URL for the authentication")
+        String tokenEndpoint;
+
+        @CommandLine.Option(
                 names = {"--client-id"},
-                description = "The client ID for authentication",
-                required = true)
+                required = true,
+                description = "The client ID for authentication")
         String clientId;
 
         @CommandLine.Option(
                 names = {"--client-secret"},
-                description = "The client secret for authentication",
-                required = true)
+                required = true,
+                description = "The client secret for authentication")
         String clientSecret;
     }
 
@@ -267,7 +267,8 @@ public class CamelToolMain implements Callable<Integer> {
                 .baseUrl(registrationUrl)
                 .serializer(new JacksonSerializer())
                 .clientId(authConfig != null ? authConfig.clientId : null)
-                .tokenEndpoint(TokenEndpoint.autoResolve(registrationUrl, tokenEndpoint))
+                .tokenEndpoint(TokenEndpoint.autoResolve(
+                        registrationUrl, authConfig != null ? authConfig.tokenEndpoint : null))
                 .secret(authConfig != null ? authConfig.clientSecret : null)
                 .build();
 

--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
@@ -114,17 +114,31 @@ public class CamelToolMain implements Callable<Integer> {
             defaultValue = "5")
     private long period;
 
-    @CommandLine.Option(
-            names = {"--routes-ref"},
-            description =
-                    "The reference path to the Apache Camel routes YAML file. Supports datastore:// and file:// schemes (e.g., datastore://routes.camel.yaml or file:///path/to/routes.yaml)")
-    private String routesRef;
+    static class RouteRefOptions {
+        @CommandLine.Option(
+                names = {"--routes-ref"},
+                required = true,
+                description =
+                        "The reference path to the Apache Camel routes YAML file. Supports datastore:// and file:// schemes (e.g., datastore://routes.camel.yaml or file:///path/to/routes.yaml)")
+        private String routesRef;
 
-    @CommandLine.Option(
-            names = {"--rules-ref"},
-            description =
-                    "The path to the YAML file with route exposure rules. Supports datastore:// and file:// schemes (e.g., datastore://routes-expose.yaml or file:///path/to/rules.yaml)")
-    private String rulesRef;
+        @CommandLine.Option(
+                names = {"--rules-ref"},
+                required = true,
+                description =
+                        "The path to the YAML file with route exposure rules. Supports datastore:// and file:// schemes (e.g., datastore://routes-expose.yaml or file:///path/to/rules.yaml)")
+        private String rulesRef;
+
+        @CommandLine.Option(
+                names = {"-d", "--dependencies"},
+                required = true,
+                description =
+                        "The dependencies to include in runtime. Supports datastore:// and file:// schemes (comma-separated)")
+        private String dependenciesRef;
+    }
+
+    @CommandLine.ArgGroup(exclusive = false)
+    private RouteRefOptions routeRefOptions;
 
     @CommandLine.Option(
             names = {"--token-endpoint"},
@@ -156,12 +170,6 @@ public class CamelToolMain implements Callable<Integer> {
     private boolean noWait;
 
     @CommandLine.Option(
-            names = {"-d", "--dependencies"},
-            description =
-                    "The dependencies to include in runtime. Supports datastore:// and file:// schemes (comma-separated)")
-    private String dependenciesRef;
-
-    @CommandLine.Option(
             names = {"--repositories"},
             description =
                     "Comma-separated list of additional repositories from which to download dependencies to include in runtime (i.e.: https://my-private-repo.com/) ")
@@ -179,16 +187,22 @@ public class CamelToolMain implements Callable<Integer> {
                     "Git repository URL to clone during initialization. Cloned files can be referenced using file:// (e.g., git@github.com:wanaku-ai/wanaku-recipes.git)")
     private String initFrom;
 
-    @CommandLine.Option(
-            names = {"--service-catalog"},
-            description =
-                    "The name of the service catalog to use. Mutually exclusive with --routes-ref, --rules-ref, and --dependencies. Requires --service-catalog-system.")
-    private String serviceCatalog;
+    static class ServiceCatalogOptions {
+        @CommandLine.Option(
+                names = {"--service-catalog"},
+                required = true,
+                description = "The name of the service catalog to use")
+        private String serviceCatalog;
 
-    @CommandLine.Option(
-            names = {"--service-catalog-system"},
-            description = "The system name within the service catalog to use (e.g., employee-check)")
-    private String serviceCatalogSystem;
+        @CommandLine.Option(
+                names = {"--service-catalog-system"},
+                required = true,
+                description = "The system name within the service catalog to use (e.g., employee-check)")
+        private String serviceCatalogSystem;
+    }
+
+    @CommandLine.ArgGroup(exclusive = false)
+    private ServiceCatalogOptions serviceCatalogOptions;
 
     @CommandLine.Option(
             names = {"--fail-fast"},
@@ -332,9 +346,12 @@ public class CamelToolMain implements Callable<Integer> {
 
         final Map<ResourceType, Path> downloadedResources;
 
-        if (serviceCatalog != null) {
+        if (serviceCatalogOptions != null) {
             ServiceCatalogDownloaderCallback catalogCallback = new ServiceCatalogDownloaderCallback(
-                    downloaderFactory, serviceCatalog, serviceCatalogSystem, downloaderConfig);
+                    downloaderFactory,
+                    serviceCatalogOptions.serviceCatalog,
+                    serviceCatalogOptions.serviceCatalogSystem,
+                    downloaderConfig);
 
             newRegistrationManager(serviceTarget, catalogCallback, serviceConfig);
 
@@ -346,9 +363,9 @@ public class CamelToolMain implements Callable<Integer> {
             downloadedResources = catalogCallback.getDownloadedResources();
         } else {
             List<ResourceRefs<URI>> resources = ResourceListBuilder.newBuilder()
-                    .addRoutesRef(routesRef)
-                    .addRulesRef(rulesRef)
-                    .addDependenciesRef(dependenciesRef)
+                    .addRoutesRef(routeRefOptions.routesRef)
+                    .addRulesRef(routeRefOptions.rulesRef)
+                    .addDependenciesRef(routeRefOptions.dependenciesRef)
                     .build();
 
             ResourceDownloaderCallback resourcesDownloaderCallback =
@@ -367,21 +384,13 @@ public class CamelToolMain implements Callable<Integer> {
     }
 
     private void validateOptions() {
-        boolean hasServiceCatalog = serviceCatalog != null && !serviceCatalog.isBlank();
-        boolean hasIndividualRefs = routesRef != null || rulesRef != null || dependenciesRef != null;
-
-        if (hasServiceCatalog && hasIndividualRefs) {
+        if (routeRefOptions != null && serviceCatalogOptions != null) {
             throw new CommandLine.ParameterException(
                     new CommandLine(this),
                     "--service-catalog is mutually exclusive with --routes-ref, --rules-ref, and --dependencies");
         }
 
-        if (hasServiceCatalog && (serviceCatalogSystem == null || serviceCatalogSystem.isBlank())) {
-            throw new CommandLine.ParameterException(
-                    new CommandLine(this), "--service-catalog-system is required when --service-catalog is used");
-        }
-
-        if (!hasServiceCatalog && (routesRef == null || routesRef.isBlank())) {
+        if (routeRefOptions == null && serviceCatalogOptions == null) {
             throw new CommandLine.ParameterException(
                     new CommandLine(this), "Either --routes-ref or --service-catalog must be provided");
         }

--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
@@ -137,9 +137,6 @@ public class CamelToolMain implements Callable<Integer> {
         private String dependenciesRef;
     }
 
-    @CommandLine.ArgGroup(exclusive = false)
-    private RouteRefOptions routeRefOptions;
-
     static class AuthConfig {
         @CommandLine.Option(
                 names = {"--token-endpoint"},
@@ -201,8 +198,16 @@ public class CamelToolMain implements Callable<Integer> {
         private String serviceCatalogSystem;
     }
 
-    @CommandLine.ArgGroup(exclusive = false)
-    private ServiceCatalogOptions serviceCatalogOptions;
+    static class ResourceSourceOptions {
+        @CommandLine.ArgGroup(exclusive = false)
+        RouteRefOptions routeRefOptions;
+
+        @CommandLine.ArgGroup(exclusive = false)
+        ServiceCatalogOptions serviceCatalogOptions;
+    }
+
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+    private ResourceSourceOptions resourceSourceOptions;
 
     @CommandLine.Option(
             names = {"--fail-fast"},
@@ -251,8 +256,6 @@ public class CamelToolMain implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
         LOG.info("Camel Integration Capability {} is starting", VersionHelper.VERSION);
-
-        validateOptions();
 
         // Create the data directory first (needed by initializers)
         Path dataDirPath = Paths.get(dataDir);
@@ -347,11 +350,11 @@ public class CamelToolMain implements Callable<Integer> {
 
         final Map<ResourceType, Path> downloadedResources;
 
-        if (serviceCatalogOptions != null) {
+        if (resourceSourceOptions.serviceCatalogOptions != null) {
             ServiceCatalogDownloaderCallback catalogCallback = new ServiceCatalogDownloaderCallback(
                     downloaderFactory,
-                    serviceCatalogOptions.serviceCatalog,
-                    serviceCatalogOptions.serviceCatalogSystem,
+                    resourceSourceOptions.serviceCatalogOptions.serviceCatalog,
+                    resourceSourceOptions.serviceCatalogOptions.serviceCatalogSystem,
                     downloaderConfig);
 
             newRegistrationManager(serviceTarget, catalogCallback, serviceConfig);
@@ -364,9 +367,9 @@ public class CamelToolMain implements Callable<Integer> {
             downloadedResources = catalogCallback.getDownloadedResources();
         } else {
             List<ResourceRefs<URI>> resources = ResourceListBuilder.newBuilder()
-                    .addRoutesRef(routeRefOptions.routesRef)
-                    .addRulesRef(routeRefOptions.rulesRef)
-                    .addDependenciesRef(routeRefOptions.dependenciesRef)
+                    .addRoutesRef(resourceSourceOptions.routeRefOptions.routesRef)
+                    .addRulesRef(resourceSourceOptions.routeRefOptions.rulesRef)
+                    .addDependenciesRef(resourceSourceOptions.routeRefOptions.dependenciesRef)
                     .build();
 
             ResourceDownloaderCallback resourcesDownloaderCallback =
@@ -382,19 +385,6 @@ public class CamelToolMain implements Callable<Integer> {
             downloadedResources = resourcesDownloaderCallback.getDownloadedResources();
         }
         return new RegistrationResult(downloadedResources, serviceTarget);
-    }
-
-    private void validateOptions() {
-        if (routeRefOptions != null && serviceCatalogOptions != null) {
-            throw new CommandLine.ParameterException(
-                    new CommandLine(this),
-                    "--service-catalog is mutually exclusive with --routes-ref, --rules-ref, and --dependencies");
-        }
-
-        if (routeRefOptions == null && serviceCatalogOptions == null) {
-            throw new CommandLine.ParameterException(
-                    new CommandLine(this), "Either --routes-ref or --service-catalog must be provided");
-        }
     }
 
     public McpSpec createMcpSpec(ServiceConfig serviceConfig, Map<ResourceType, Path> downloadedResources) {


### PR DESCRIPTION
## Summary
- Replace manual dependency validation with picocli `@ArgGroup(exclusive = false)` for two option groups:
  - `--routes-ref`, `--rules-ref`, `--dependencies` must all be provided together
  - `--service-catalog`, `--service-catalog-system` must both be provided together
- Simplify `validateOptions()` since picocli now enforces co-occurrence

## Test plan
- [ ] Verify `--routes-ref` alone fails requiring `--rules-ref` and `--dependencies`
- [ ] Verify `--service-catalog` alone fails requiring `--service-catalog-system`
- [ ] Verify providing all three route ref options works
- [ ] Verify providing both service catalog options works
- [ ] Verify mixing both groups still fails

## Summary by Sourcery

Use picocli argument groups to enforce mutually dependent CLI options and simplify option validation.

New Features:
- Introduce picocli ArgGroup for route reference options, requiring routes, rules, and dependencies flags to be provided together.
- Introduce picocli ArgGroup for service catalog options, requiring catalog name and system to be provided together.

Enhancements:
- Simplify CLI option validation logic by delegating co-occurrence checks to picocli and only enforcing mutual exclusivity between option groups.