### PR TITLE
Fix issue #108

### DIFF
--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
@@ -68,6 +68,7 @@ public class CamelToolMain implements Callable<Integer> {
     @CommandLine.Option(
             names = {"--registration-url"},
             description = "The registration URL to use",
+            defaultValue = "http://localhost:8080",
             required = true)
     private String registrationUrl;
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Provide a default localhost registration URL for the command-line --registration-url option to simplify configuration.