### PR TITLE
chore: support releasing from branches instead of main

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -17,6 +17,15 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Determine SDK ref
+        id: sdk-ref
+        run: |
+          BRANCH="${GITHUB_REF_NAME}"
+          if git ls-remote --heads https://github.com/wanaku-ai/wanaku-capabilities-java-sdk.git "$BRANCH" | grep -q .; then
+            echo "ref=$BRANCH" >> $GITHUB_OUTPUT
+          else
+            echo "ref=main" >> $GITHUB_OUTPUT
+          fi
       - uses: actions/checkout@v6
       - name: Set up JDK 21
         uses: actions/setup-java@v5
@@ -27,7 +36,7 @@ jobs:
       - name: Checkout and build dependencies
         run: |
           cd ..
-          git clone https://github.com/wanaku-ai/wanaku-capabilities-java-sdk.git
+          git clone -b ${{ steps.sdk-ref.outputs.ref }} https://github.com/wanaku-ai/wanaku-capabilities-java-sdk.git
           cd wanaku-capabilities-java-sdk
           mvn -DskipTests -B install --file pom.xml
           cd ${{ github.workspace }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
         - main
+        - '[0-9]*.[0-9]*.x'
     tags:
       - v*
     paths-ignore:
@@ -34,10 +35,19 @@ jobs:
         java-version: '21'
         distribution: 'temurin'
         cache: maven
+    - name: Determine SDK ref
+      id: sdk-ref
+      run: |
+        BRANCH="${GITHUB_REF_NAME}"
+        if git ls-remote --heads https://github.com/wanaku-ai/wanaku-capabilities-java-sdk.git "$BRANCH" | grep -q .; then
+          echo "ref=$BRANCH" >> $GITHUB_OUTPUT
+        else
+          echo "ref=main" >> $GITHUB_OUTPUT
+        fi
     - name: Checkout and build dependencies
       run: |
         cd ..
-        git clone https://github.com/wanaku-ai/wanaku-capabilities-java-sdk.git
+        git clone -b ${{ steps.sdk-ref.outputs.ref }} https://github.com/wanaku-ai/wanaku-capabilities-java-sdk.git
         cd wanaku-capabilities-java-sdk
         mvn -DskipTests -B install --file pom.xml
         cd ${{ github.workspace }}

--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - "main"
+      - '[0-9]*.[0-9]*.x'
     paths-ignore:
       - .github/**
       - docs/**
@@ -31,6 +32,16 @@ jobs:
       fail-fast: true
 
     steps:
+    - name: Determine SDK ref
+      id: sdk-ref
+      shell: bash
+      run: |
+        BRANCH="${{ github.base_ref }}"
+        if git ls-remote --heads https://github.com/wanaku-ai/wanaku-capabilities-java-sdk.git "$BRANCH" | grep -q .; then
+          echo "ref=$BRANCH" >> $GITHUB_OUTPUT
+        else
+          echo "ref=main" >> $GITHUB_OUTPUT
+        fi
     - uses: actions/checkout@v6
     - name: Set up JDK 21
       uses: actions/setup-java@v5
@@ -41,7 +52,7 @@ jobs:
     - name: Checkout and build dependencies
       run: |
         cd ..
-        git clone https://github.com/wanaku-ai/wanaku-capabilities-java-sdk.git
+        git clone -b ${{ steps.sdk-ref.outputs.ref }} https://github.com/wanaku-ai/wanaku-capabilities-java-sdk.git
         cd wanaku-capabilities-java-sdk
         mvn -DskipTests -B install --file pom.xml
         cd ${{ github.workspace }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
       nextDevelopmentVersion:
         description: 'The next development version'
         required: true
+      releaseBranch:
+        description: 'The release branch (e.g., 0.1.x)'
+        required: true
 
 jobs:
   release:
@@ -22,6 +25,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.releaseBranch }}
 
       # Configure build steps as you'd normally do
 
@@ -36,7 +40,9 @@ jobs:
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
-          mvn -B --file pom.xml -Dtag=camel-integration-capability-${{ github.event.inputs.currentDevelopmentVersion }} -DreleaseVersion=${{ github.event.inputs.currentDevelopmentVersion }} -DdevelopmentVersion=${{ github.event.inputs.nextDevelopmentVersion }}-SNAPSHOT release:prepare release:perform -Dgoals=install
+          mvn -B --file pom.xml -Dtag=camel-integration-capability-${{ github.event.inputs.currentDevelopmentVersion }} -DreleaseVersion=${{ github.event.inputs.currentDevelopmentVersion }} -DdevelopmentVersion=${{ github.event.inputs.nextDevelopmentVersion }}-SNAPSHOT release:prepare
+          git push origin HEAD:${{ github.event.inputs.releaseBranch }} camel-integration-capability-${{ github.event.inputs.currentDevelopmentVersion }}
+          mvn -B --file pom.xml release:perform -Dgoals=install
 
       # Create a release
 

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -4,7 +4,7 @@
 
 Before triggering a release, verify the following:
 
-- [ ] All tests passing on the `main` branch
+- [ ] All tests passing on the release branch
 - [ ] Version numbers consistent across all module POMs
 - [ ] No unintended SNAPSHOT dependencies
 - [ ] Documentation updated for new features
@@ -12,18 +12,33 @@ Before triggering a release, verify the following:
 
 ## Triggering a Release
 
-Export the version variables:
+Releases are cut from release branches following the `X.Y.x` naming convention (e.g., `0.1.x`, `0.2.x`).
+
+### Create the release branch (first release of a minor version only)
 
 ```shell
-export CURRENT_DEVELOPMENT_VERSION=0.1.1
-export NEXT_DEVELOPMENT_VERSION=0.2.0
+git checkout main
+git checkout -b 0.2.x
+git push origin 0.2.x
 ```
 
-Trigger the release automation:
+### Set the versions
 
 ```shell
-gh workflow run release -f currentDevelopmentVersion=${CURRENT_DEVELOPMENT_VERSION} -f nextDevelopmentVersion=${NEXT_DEVELOPMENT_VERSION}
+export RELEASE_BRANCH=0.2.x
+export CURRENT_DEVELOPMENT_VERSION=0.2.0
+export NEXT_DEVELOPMENT_VERSION=0.2.1
 ```
+
+### Trigger the release
+
+```shell
+gh workflow run release -r ${RELEASE_BRANCH} -f releaseBranch=${RELEASE_BRANCH} -f currentDevelopmentVersion=${CURRENT_DEVELOPMENT_VERSION} -f nextDevelopmentVersion=${NEXT_DEVELOPMENT_VERSION}
+```
+
+> [!NOTE]
+> The `-r` flag tells GitHub to run the workflow from the release branch. The `releaseBranch` input tells the
+> workflow which branch to check out and push version bump commits to.
 
 ## Post-Release
 


### PR DESCRIPTION
## Summary

- Add `releaseBranch` input to `release.yml` so releases are cut from `X.Y.x` branches instead of `main`
- Split `release:prepare` and `release:perform` so version bump commits are pushed to the release branch between the two phases
- Add release branch triggers (`[0-9]*.[0-9]*.x`) to `main-build.yml` and `pr-builds.yml`
- Add SDK branch-matching logic to all CI workflows (tries matching branch on `wanaku-capabilities-java-sdk`, falls back to `main`)
- Update `docs/release-guide.md` with branch-based release instructions

## Test plan

- [ ] Create a test release branch (e.g. `0.1.x`) and verify `main-build.yml` triggers on push
- [ ] Open a PR targeting the release branch and verify `pr-builds.yml` runs
- [ ] Dry-run the release workflow with `releaseBranch` input
- [ ] Verify `release-artifacts.yml` still works unchanged (tag-based checkout)

## Summary by Sourcery

Support cutting releases from versioned release branches instead of main and align CI workflows and docs with branch-based releases.

Enhancements:
- Add support for a configurable release branch in the release workflow and push version bump commits back to that branch.
- Update main and PR build workflows to trigger on versioned release branches and to match the Java SDK branch when available, falling back to main.
- Align early-access workflow dependency checkout with branch-matching behavior used in other workflows.

CI:
- Extend CI triggers to include versioned release branches and ensure all workflows clone the matching SDK branch when it exists.

Documentation:
- Update the release guide to document branch-based release flow, including creating release branches and invoking the release workflow with the new parameters.