### PR TITLE
ci: exclude old maven-resolver-supplier to fix test failures

### DIFF
--- a/camel-integration-capability-common/pom.xml
+++ b/camel-integration-capability-common/pom.xml
@@ -49,6 +49,12 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-kamelet-main</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.maven.resolver</groupId>
+                    <artifactId>maven-resolver-supplier</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>


### PR DESCRIPTION
## CI Fix

**Failed run:** https://github.com/wanaku-ai/camel-integration-capability/actions/runs/28668067208

### Root Cause

`camel-kamelet-main:4.20.0` transitively pulls in `maven-resolver-supplier:1.9.27` (pre-split artifact) via `camel-tooling-maven`. The SDK's `capabilities-maven-downloader` brings in `maven-resolver-supplier-mvn3:2.0.18` (post-split). Both jars provide `org.eclipse.aether.supplier.RepositorySystemSupplier`, but Maven doesn't detect a conflict because they have different artifact IDs.

At runtime, the classloader picks the old `RepositorySystemSupplier` (1.9.27) which references `DefaultTrackingFileManager` — a class removed in `maven-resolver-impl:2.0.18` (the version Maven resolves to). This causes `NoClassDefFoundError` in all integration tests.

### Fix

Exclude `maven-resolver-supplier` (the old, pre-split artifact) from `camel-kamelet-main` in `camel-integration-capability-common/pom.xml`.

### Deferred Issues

- Apache Camel's `camel-tooling-maven` should migrate from the deprecated `maven-resolver-supplier` to `maven-resolver-supplier-mvn3` to avoid this class of conflict for all consumers.