### PR TITLE
ci: pin GitHub Actions to SHA hashes and upgrade to latest versions

### DIFF
--- a/.github/workflows/depsreview.yaml
+++ b/.github/workflows/depsreview.yaml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -26,9 +26,9 @@ jobs:
           else
             echo "ref=main" >> $GITHUB_OUTPUT
           fi
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -47,7 +47,7 @@ jobs:
         run: echo "arch=$(uname -m)" >> $GITHUB_OUTPUT
       - name: Login to Container Registry
         if: github.repository == 'wanaku-ai/camel-integration-capability'
-        uses: docker/login-action@v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
@@ -61,7 +61,7 @@ jobs:
 
       - name: Run JReleaser (Linux)
         if: matrix.os == 'ubuntu-latest' && github.repository == 'wanaku-ai/camel-integration-capability'
-        uses: jreleaser/release-action@v2
+        uses: jreleaser/release-action@90ac653bb9c79d11179e65d81499f3f34527dcd5 # v2.5.0
         env:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JRELEASER_PROJECT_VERSION: ${{ github.event.inputs.currentDevelopmentVersion }}
@@ -75,7 +75,7 @@ jobs:
 
       - name: JReleaser release output
         if: matrix.os == 'ubuntu-latest' && github.repository == 'wanaku-ai/camel-integration-capability'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jreleaser-release-linux
           path: |
@@ -86,10 +86,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Login to Container Registry
         if: github.repository == 'wanaku-ai/camel-integration-capability'
-        uses: docker/login-action@v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -28,9 +28,9 @@ jobs:
         os: [ubuntu-latest, ubuntu-24.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Set up JDK 21
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -58,7 +58,7 @@ jobs:
       run: mvn -B --no-transfer-progress surefire-report:report-only surefire-report:failsafe-report-only -Daggregate=true
     - name: Upload Test Reports
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: test-reports-${{ matrix.os }}
         path: 'target/reports/'
@@ -69,7 +69,7 @@ jobs:
       run: echo "arch=$(uname -m)" >> $GITHUB_OUTPUT
     - name: Login to Container Registry
       if: github.repository == 'wanaku-ai/camel-integration-capability'
-      uses: docker/login-action@v3
+      uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
@@ -85,10 +85,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Login to Container Registry
         if: github.repository == 'wanaku-ai/camel-integration-capability'
-        uses: docker/login-action@v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -14,5 +14,5 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: DavidAnson/markdownlint-cli2-action@v19
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: DavidAnson/markdownlint-cli2-action@8de2aa07cae85fd17c0b35642db70cf5495f1d25 # v24.0.0

--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -42,9 +42,9 @@ jobs:
         else
           echo "ref=main" >> $GITHUB_OUTPUT
         fi
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Set up JDK 21
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -63,7 +63,7 @@ jobs:
       run: mvn -B --no-transfer-progress surefire-report:report-only surefire-report:failsafe-report-only -Daggregate=true
     - name: Upload Test Reports
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: test-reports-${{ matrix.os }}
         path: 'target/reports/'

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -18,12 +18,12 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           ref: camel-integration-capability-${{ github.event.inputs.currentDevelopmentVersion }}
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -35,7 +35,7 @@ jobs:
         run: echo "arch=$(uname -m)" >> $GITHUB_OUTPUT
       - name: Login to Container Registry
         if: github.repository == 'wanaku-ai/camel-integration-capability'
-        uses: docker/login-action@v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
@@ -51,10 +51,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Login to Container Registry
         if: github.repository == 'wanaku-ai/camel-integration-capability'
-        uses: docker/login-action@v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.releaseBranch }}
@@ -30,7 +30,7 @@ jobs:
       # Configure build steps as you'd normally do
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           java-version: 21
           distribution: 'zulu'
@@ -47,7 +47,7 @@ jobs:
       # Create a release
 
       - name: Run JReleaser
-        uses: jreleaser/release-action@v2
+        uses: jreleaser/release-action@90ac653bb9c79d11179e65d81499f3f34527dcd5 # v2.5.0
         env:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JRELEASER_PROJECT_VERSION: ${{ github.event.inputs.currentDevelopmentVersion }}
@@ -61,7 +61,7 @@ jobs:
 
       - name: JReleaser release output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jreleaser-release
           path: |


### PR DESCRIPTION
## Summary

Pin all GitHub Actions to commit SHA hashes for supply-chain security and upgrade to latest versions.

| Action | Previous | New |
|--------|----------|-----|
| `actions/checkout` | v6 | v7.0.0 |
| `actions/setup-java` | v5 | v5.5.0 |
| `actions/upload-artifact` | v4 | v7.0.1 |
| `actions/dependency-review-action` | v4 | v5.0.0 |
| `docker/login-action` | v3 | v4.4.0 |
| `jreleaser/release-action` | v2 | v2.5.0 |
| `DavidAnson/markdownlint-cli2-action` | v19 | v24.0.0 |

## Test plan

- [ ] Verify PR build passes with updated actions
- [ ] Verify dependency review still runs on PRs
- [ ] Verify markdown lint still runs on PRs

## Summary by Sourcery

Pin CI workflows to specific GitHub Action commit SHAs and update them to the latest supported versions for improved supply-chain security.

CI:
- Update actions/checkout, actions/setup-java, actions/upload-artifact, docker/login-action, jreleaser/release-action, actions/dependency-review-action, and markdownlint-cli2-action to newer releases across all workflows.
- Replace version-tagged GitHub Actions references with pinned commit SHAs in build, release, PR, dependency review, and markdown lint workflows.