### PR TITLE
chore: clean up 0.2.0 release leftovers

### DIFF
--- a/camel-integration-capability-common/pom.xml
+++ b/camel-integration-capability-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>camel-integration-capability</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-integration-capability-common</artifactId>

--- a/camel-integration-capability-runtimes/camel-integration-capability-main/pom.xml
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>camel-integration-capability-runtimes</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-integration-capability-main</artifactId>

--- a/camel-integration-capability-runtimes/camel-integration-capability-plugin/pom.xml
+++ b/camel-integration-capability-runtimes/camel-integration-capability-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>camel-integration-capability-runtimes</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-integration-capability-plugin</artifactId>

--- a/camel-integration-capability-runtimes/pom.xml
+++ b/camel-integration-capability-runtimes/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>camel-integration-capability</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-integration-capability-runtimes</artifactId>

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -18,16 +18,16 @@ Releases are cut from release branches following the `X.Y.x` naming convention (
 
 ```shell
 git checkout main
-git checkout -b 0.2.x
-git push origin 0.2.x
+git checkout -b 0.3.x
+git push origin 0.3.x
 ```
 
 ### Set the versions
 
 ```shell
-export RELEASE_BRANCH=0.2.x
-export CURRENT_DEVELOPMENT_VERSION=0.2.0
-export NEXT_DEVELOPMENT_VERSION=0.2.1
+export RELEASE_BRANCH=0.3.x
+export CURRENT_DEVELOPMENT_VERSION=0.3.0
+export NEXT_DEVELOPMENT_VERSION=0.3.1
 ```
 
 ### Trigger the release

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>ai.wanaku</groupId>
     <artifactId>camel-integration-capability</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <inceptionYear>2025</inceptionYear>
     <url>https://github.com/wanaku-ai/camel-integration-capability</url>


### PR DESCRIPTION
## Summary

- Bump child module parent versions from `0.2.0-SNAPSHOT` to `0.3.0-SNAPSHOT`
- Update release guide examples to reference the `0.3.x` release cycle

## Test plan

- [ ] Verify `mvn validate` passes with updated versions

## Summary by Sourcery

Align project versions and release process with the 0.3.x development cycle.

Build:
- Bump parent and module Maven artifact versions from 0.2.0-SNAPSHOT to 0.3.0-SNAPSHOT across the project.

Documentation:
- Update release guide examples to reference the 0.3.x branch and version numbers.