### PR TITLE
chore: fix static code analysis issues

### DIFF
--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
@@ -3,7 +3,6 @@ package ai.wanaku.capability.camel;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -259,7 +258,7 @@ public class CamelToolMain implements Callable<Integer> {
         LOG.info("Camel Integration Capability {} is starting", VersionHelper.VERSION);
 
         // Create the data directory first (needed by initializers)
-        Path dataDirPath = Paths.get(dataDir);
+        Path dataDirPath = Path.of(dataDir);
         Files.createDirectories(dataDirPath);
         LOG.info("Using data directory: {}", dataDirPath.toAbsolutePath());
 

--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/WanakuCamelManager.java
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/WanakuCamelManager.java
@@ -3,11 +3,9 @@ package ai.wanaku.capability.camel;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import org.apache.camel.CamelContext;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.slf4j.Logger;
@@ -30,7 +28,7 @@ public class WanakuCamelManager {
     private final CamelContext context;
     private final String routesPath;
     private final RouteLoadingFailurePolicy routeLoadingFailurePolicy;
-    private List<GAV> gavs = new ArrayList<>();
+    private final List<GAV> gavs;
 
     public WanakuCamelManager(Map<ResourceType, Path> downloadedResources, String repositoriesList) {
         this(downloadedResources, repositoriesList, RouteLoadingFailurePolicy.FAIL_FAST);
@@ -45,18 +43,18 @@ public class WanakuCamelManager {
 
         this.routesPath = downloadedResources.get(ResourceType.ROUTES_REF).toString();
         if (downloadedResources.containsKey(ResourceType.DEPENDENCY_REF)) {
-            String dependenciesPath =
-                    downloadedResources.get(ResourceType.DEPENDENCY_REF).toString();
+            Path dependenciesPath = downloadedResources.get(ResourceType.DEPENDENCY_REF);
             try {
-                final List<String> depLines = Files.readAllLines(Path.of(dependenciesPath));
+                final List<String> depLines = Files.readAllLines(dependenciesPath);
                 this.gavs = depLines.stream()
                         .filter(l -> !l.startsWith("#"))
                         .map(g -> GAV.parse(g, RuntimeVersionHelper.getVersions()))
-                        .collect(Collectors.toList());
-
+                        .toList();
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
+        } else {
+            this.gavs = List.of();
         }
 
         WanakuMavenDownloader mavenDownloader = new WanakuMavenDownloader(WanakuCamelManager.class.getClassLoader());

--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/test/java/ai/wanaku/capability/camel/WanakuCamelRouteLoaderFailIT.java
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/test/java/ai/wanaku/capability/camel/WanakuCamelRouteLoaderFailIT.java
@@ -18,7 +18,6 @@
 package ai.wanaku.capability.camel;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Map;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceType;
 import ai.wanaku.capabilities.sdk.runtime.camel.exceptions.RouteLoadingException;
@@ -31,8 +30,8 @@ class WanakuCamelRouteLoaderFailIT {
 
     @Test
     void throwsErrorOnFailFast() {
-        Path routesFile = Paths.get("src", "test", "resources", "test-routes-with-errors.camel.yaml");
-        Path dependenciesFile = Paths.get("src", "test", "resources", "test-routes-dependencies.txt");
+        Path routesFile = Path.of("src", "test", "resources", "test-routes-with-errors.camel.yaml");
+        Path dependenciesFile = Path.of("src", "test", "resources", "test-routes-dependencies.txt");
 
         Map<ResourceType, Path> downloadedResources = Map.of(
                 ResourceType.ROUTES_REF, routesFile,
@@ -43,8 +42,8 @@ class WanakuCamelRouteLoaderFailIT {
 
     @Test
     void doesNotThrowErrorOnFailFast() {
-        Path routesFile = Paths.get("src", "test", "resources", "test-routes-with-errors.camel.yaml");
-        Path dependenciesFile = Paths.get("src", "test", "resources", "test-routes-dependencies.txt");
+        Path routesFile = Path.of("src", "test", "resources", "test-routes-with-errors.camel.yaml");
+        Path dependenciesFile = Path.of("src", "test", "resources", "test-routes-dependencies.txt");
 
         Map<ResourceType, Path> downloadedResources = Map.of(
                 ResourceType.ROUTES_REF, routesFile,

--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/test/java/ai/wanaku/capability/camel/WanakuCamelRouteLoaderIT.java
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/test/java/ai/wanaku/capability/camel/WanakuCamelRouteLoaderIT.java
@@ -18,7 +18,6 @@
 package ai.wanaku.capability.camel;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Map;
 import java.util.regex.Pattern;
 import org.apache.camel.CamelContext;
@@ -39,8 +38,8 @@ class WanakuCamelRouteLoaderIT {
 
     @BeforeAll
     static void setUp() throws Exception {
-        Path routesFile = Paths.get("src", "test", "resources", "test-routes.camel.yaml");
-        Path dependenciesFile = Paths.get("src", "test", "resources", "test-routes-dependencies.txt");
+        Path routesFile = Path.of("src", "test", "resources", "test-routes.camel.yaml");
+        Path dependenciesFile = Path.of("src", "test", "resources", "test-routes-dependencies.txt");
 
         Map<ResourceType, Path> downloadedResources = Map.of(
                 ResourceType.ROUTES_REF, routesFile,
@@ -135,8 +134,8 @@ class WanakuCamelRouteLoaderIT {
 
     @Test
     void emptyRouteDefinitionsCanContinueInLenientMode() {
-        Path routesFile = Paths.get("src", "test", "resources", "empty-routes.camel.yaml");
-        Path dependenciesFile = Paths.get("src", "test", "resources", "test-routes-dependencies.txt");
+        Path routesFile = Path.of("src", "test", "resources", "empty-routes.camel.yaml");
+        Path dependenciesFile = Path.of("src", "test", "resources", "test-routes-dependencies.txt");
 
         Map<ResourceType, Path> downloadedResources = Map.of(
                 ResourceType.ROUTES_REF, routesFile,


### PR DESCRIPTION
## Summary
- Replace deprecated `Paths.get()` with `Path.of()` across all source and test files (available since Java 11)
- Replace `Collectors.toList()` with `Stream.toList()` in `WanakuCamelManager` (available since Java 16)
- Make `gavs` field `final` by properly initializing it in both branches of the constructor
- Eliminate redundant `Path→String→Path` conversion for `dependenciesPath` in `WanakuCamelManager`
- Remove unused imports (`Paths`, `Collectors`, `ArrayList`)

## Test plan
- [x] Spotless check passes
- [x] Compilation succeeds (`mvn compile test-compile`)
- [ ] CI build passes

## Summary by Sourcery

Modernize file handling and collection usage in the Camel integration capability and tests to address static analysis findings.

Enhancements:
- Make the WanakuCamelManager GAV list field final with consistent initialization when dependency references are present or absent.
- Simplify dependency file path handling by operating directly on Path instances and using Stream.toList() for collecting GAVs.
- Update main tooling and integration tests to use Path.of() instead of deprecated Paths.get().

Chores:
- Remove unused imports related to legacy path and collection APIs across main and test sources.