### PR TITLE
chore: pass current branch to early-access workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 early-build:
-	gh workflow run early-access -f currentDevelopmentVersion=`cat camel-integration-capability-common/target/classes/cic-version.txt`
+	gh workflow run early-access --ref $$(git rev-parse --abbrev-ref HEAD) -f currentDevelopmentVersion=`cat camel-integration-capability-common/target/classes/cic-version.txt`


### PR DESCRIPTION
## Summary
- The `early-build` Makefile target now passes `--ref` with the current branch to `gh workflow run`, so the workflow runs on the correct branch instead of defaulting to the repo's default branch.

## Summary by Sourcery

Build:
- Change the early-build Makefile target to modify the invocation of the early-access GitHub Actions workflow.