### PR TITLE
feat: support for the camel-heath

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ COPY camel-integration-capability-runtimes/camel-integration-capability-main/tar
 
 # Environment variables for runtime configuration
 ENV REGISTRATION_URL="" \
+    HEALTH_PORT="8081" \
     SERVICE_NAME="" \
     ROUTES_PATH="" \
     SERVICE_CATALOG="" \
@@ -23,8 +24,9 @@ ENV REGISTRATION_URL="" \
 # Create and declare volume for routes data
 VOLUME /data
 
-# Expose the MCP server port
+# Expose the MCP server port and the HTTP health check port
 EXPOSE ${MCP_PORT}
+EXPOSE ${HEALTH_PORT}
 
 # Run the application with environment variables.
 # This part uses shell parameter expansion to conditionally add command-line arguments to the Java application.
@@ -32,6 +34,7 @@ EXPOSE ${MCP_PORT}
 # with value. Otherwise, substitute it with nothing (an empty string)."
 ENTRYPOINT ["sh", "-c", "java -jar /app/app.jar \
     ${REGISTRATION_URL:+--registration-url $REGISTRATION_URL} \
+    ${HEALTH_PORT:+--health-port $HEALTH_PORT} \
     ${SERVICE_NAME:+--name $SERVICE_NAME} \
     ${ROUTES_PATH:+--routes-ref $ROUTES_PATH} \
     ${SERVICE_CATALOG:+--service-catalog $SERVICE_CATALOG} \

--- a/camel-integration-capability-runtimes/camel-integration-capability-main/pom.xml
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/pom.xml
@@ -45,6 +45,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
+            <artifactId>camel-health</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
             <artifactId>camel-mcp-server</artifactId>
         </dependency>
         <dependency>
@@ -72,6 +76,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/CamelToolMain.java
@@ -46,6 +46,26 @@ public class CamelToolMain implements Callable<Integer> {
     private String registrationUrl;
 
     @CommandLine.Option(
+            names = {"--health-port"},
+            description =
+                    "The HTTP port for the health check endpoints (/observe/health, /observe/health/live, /observe/health/ready)",
+            defaultValue = "8081")
+    private int healthPort;
+
+    @CommandLine.Option(
+            names = {"--no-health"},
+            description = "Disable the HTTP health check endpoints",
+            defaultValue = "false")
+    private boolean noHealth;
+
+    @CommandLine.Option(
+            names = {"--registration-announce-address"},
+            description = "The announce address to use when registering",
+            defaultValue = "auto",
+            required = true)
+    private String registrationAnnounceAddress;
+
+    @CommandLine.Option(
             names = {"--name"},
             description = "The service name to use",
             defaultValue = "camel")
@@ -169,8 +189,8 @@ public class CamelToolMain implements Callable<Integer> {
                 ? WanakuCamelManager.RouteLoadingFailurePolicy.FAIL_FAST
                 : WanakuCamelManager.RouteLoadingFailurePolicy.LOG_AND_CONTINUE;
 
-        WanakuCamelManager camelManager =
-                new WanakuCamelManager(downloadedResources, repositoriesList, mcpTags, mcpPort, policy);
+        WanakuCamelManager camelManager = new WanakuCamelManager(
+                downloadedResources, repositoriesList, mcpTags, mcpPort, noHealth ? 0 : healthPort, policy);
         camelManager.run();
 
         return 0;

--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/WanakuCamelManager.java
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/main/java/ai/wanaku/capability/camel/WanakuCamelManager.java
@@ -11,6 +11,8 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.component.mcp.server.McpServerBridge;
 import org.apache.camel.component.mcp.server.McpServerConfiguration;
 import org.apache.camel.component.platform.http.main.MainHttpServer;
+import org.apache.camel.component.platform.http.main.ManagementHttpServer;
+import org.apache.camel.health.HealthCheckRegistry;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,6 +25,9 @@ import ai.wanaku.capabilities.sdk.runtime.camel.versions.RuntimeVersionHelper;
 
 public class WanakuCamelManager {
     private static final Logger LOG = LoggerFactory.getLogger(WanakuCamelManager.class);
+
+    // Camel's default management health path; sub-paths /live and /ready are added automatically
+    private static final String HEALTH_PATH = "/observe/health";
 
     public enum RouteLoadingFailurePolicy {
         FAIL_FAST,
@@ -39,6 +44,16 @@ public class WanakuCamelManager {
             String repositoriesList,
             String mcpTags,
             int mcpPort,
+            RouteLoadingFailurePolicy routeLoadingFailurePolicy) {
+        this(downloadedResources, repositoriesList, mcpTags, mcpPort, 0, routeLoadingFailurePolicy);
+    }
+
+    public WanakuCamelManager(
+            Map<ResourceType, Path> downloadedResources,
+            String repositoriesList,
+            String mcpTags,
+            int mcpPort,
+            int healthPort,
             RouteLoadingFailurePolicy routeLoadingFailurePolicy) {
         this.routeLoadingFailurePolicy =
                 Objects.requireNonNull(routeLoadingFailurePolicy, "RouteLoadingFailurePolicy must not be null");
@@ -72,6 +87,62 @@ public class WanakuCamelManager {
         }
 
         loadRoutes();
+        configureHealthChecks();
+
+        if (healthPort > 0) {
+            setupManagementServer(healthPort);
+        }
+    }
+
+    private void configureHealthChecks() {
+        HealthCheckRegistry healthCheckRegistry = HealthCheckRegistry.get(context);
+        if (healthCheckRegistry == null) {
+            LOG.warn("No HealthCheckRegistry available: health checks are disabled");
+            return;
+        }
+
+        healthCheckRegistry.setEnabled(true);
+        // With the "default" exposure level Camel collapses all-UP results into a single
+        // summary entry; "full" reports every check individually
+        healthCheckRegistry.setExposureLevel("full");
+
+        // A plain CamelContext does not register the standard checks on its own (camel-main
+        // does it during auto-configuration), so resolve and register them explicitly
+        registerHealthCheck(healthCheckRegistry, "context");
+        registerHealthCheck(healthCheckRegistry, "routes");
+        registerHealthCheck(healthCheckRegistry, "consumers");
+    }
+
+    private static void registerHealthCheck(HealthCheckRegistry healthCheckRegistry, String id) {
+        Object check = healthCheckRegistry.resolveById(id);
+        if (check != null) {
+            healthCheckRegistry.register(check);
+        } else {
+            LOG.warn("Unable to resolve health check '{}'", id);
+        }
+    }
+
+    /**
+     * Sets up Camel's built-in management HTTP server exposing the Camel Health Check API
+     * at {@code /observe/health} (all checks), {@code /observe/health/live} (liveness) and
+     * {@code /observe/health/ready} (readiness), for Kubernetes/container probes.
+     */
+    private void setupManagementServer(int healthPort) {
+        try {
+            ManagementHttpServer managementServer = new ManagementHttpServer();
+            managementServer.setPort(healthPort);
+            managementServer.setHealthCheckEnabled(true);
+            managementServer.setHealthPath(HEALTH_PATH);
+            context.addService(managementServer);
+            LOG.info(
+                    "HTTP health endpoints available on port {} ({}, {}/live, {}/ready)",
+                    healthPort,
+                    HEALTH_PATH,
+                    HEALTH_PATH,
+                    HEALTH_PATH);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to setup management HTTP server", e);
+        }
     }
 
     private void setupMcpServer(String mcpTags, int mcpPort) {

--- a/camel-integration-capability-runtimes/camel-integration-capability-main/src/test/java/ai/wanaku/capability/camel/CamelHealthEndpointsIT.java
+++ b/camel-integration-capability-runtimes/camel-integration-capability-main/src/test/java/ai/wanaku/capability/camel/CamelHealthEndpointsIT.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.wanaku.capability.camel;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import java.util.Map;
+import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceType;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CamelHealthEndpointsIT {
+
+    private static WanakuCamelManager camelManager;
+    private static int healthPort;
+    private static HttpClient httpClient;
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        Path routesFile = Path.of("src", "test", "resources", "test-routes.camel.yaml");
+        Path dependenciesFile = Path.of("src", "test", "resources", "test-routes-dependencies.txt");
+
+        Map<ResourceType, Path> downloadedResources = Map.of(
+                ResourceType.ROUTES_REF, routesFile,
+                ResourceType.DEPENDENCY_REF, dependenciesFile);
+
+        healthPort = findFreePort();
+        camelManager = new WanakuCamelManager(
+                downloadedResources, null, null, 0, healthPort, WanakuCamelManager.RouteLoadingFailurePolicy.FAIL_FAST);
+        camelManager.start();
+
+        httpClient = HttpClient.newHttpClient();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (camelManager != null) {
+            camelManager.stop();
+        }
+    }
+
+    private static int findFreePort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+
+    private static HttpResponse<String> get(String path) throws Exception {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:" + healthPort + path))
+                .GET()
+                .build();
+        return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    @Test
+    void healthEndpointReportsUp() throws Exception {
+        HttpResponse<String> response = get("/observe/health");
+
+        assertEquals(200, response.statusCode(), "/observe/health should return 200 when the context is started");
+
+        JsonNode body = MAPPER.readTree(response.body());
+        assertEquals("UP", body.get("status").asText(), "Overall status should be UP");
+        assertTrue(body.get("checks").isArray(), "Response should contain a checks array");
+        assertTrue(body.get("checks").size() > 0, "At least one health check should be registered");
+    }
+
+    @Test
+    void livenessEndpointReportsUp() throws Exception {
+        HttpResponse<String> response = get("/observe/health/live");
+
+        assertEquals(200, response.statusCode(), "/observe/health/live should return 200 when the context is started");
+        assertEquals("UP", MAPPER.readTree(response.body()).get("status").asText(), "Liveness status should be UP");
+    }
+
+    @Test
+    void readinessEndpointReportsUpWithRouteChecks() throws Exception {
+        HttpResponse<String> response = get("/observe/health/ready");
+
+        assertEquals(200, response.statusCode(), "/observe/health/ready should return 200 when routes are started");
+
+        JsonNode body = MAPPER.readTree(response.body());
+        assertEquals("UP", body.get("status").asText(), "Readiness status should be UP");
+
+        boolean hasRouteCheck = false;
+        for (JsonNode check : body.get("checks")) {
+            if (check.get("name").asText().startsWith("route:")) {
+                hasRouteCheck = true;
+                assertEquals("UP", check.get("status").asText(), "Route checks should be UP");
+            }
+        }
+        assertTrue(hasRouteCheck, "Readiness should include route-level checks, got: " + response.body());
+    }
+
+    @Test
+    void contextCheckIsReported() throws Exception {
+        HttpResponse<String> response = get("/observe/health");
+
+        JsonNode body = MAPPER.readTree(response.body());
+        boolean hasContextCheck = false;
+        for (JsonNode check : body.get("checks")) {
+            if ("context".equals(check.get("name").asText())) {
+                hasContextCheck = true;
+                assertEquals("UP", check.get("status").asText(), "Context check should be UP");
+            }
+        }
+        assertTrue(hasContextCheck, "Health should include the context check, got: " + response.body());
+    }
+}

--- a/docs/building.md
+++ b/docs/building.md
@@ -55,7 +55,7 @@ podman build -t camel-integration-capability:latest .
 ## Architecture
 
 - **Common Module** (`camel-integration-capability-common`):
-  - Shared utilities, models, and gRPC services
+  - Shared utilities and models
   - No CLI or logging dependencies
   - Can be used as a library
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -98,6 +98,8 @@ Control the built-in MCP server (HTTP/SSE transport).
 | Parameter | Environment Variable | Required | Default | Description |
 |-----------|---------------------|----------|---------|-------------|
 | `--mcp-port` | `MCP_PORT` | No | `8080` | Port the MCP server listens on. Clients connect to this port using HTTP/SSE transport. |
+| `--health-port` | - | No | `8081` | Port for the HTTP health check endpoints (`/observe/health`, `/observe/health/live`, `/observe/health/ready`), served by Camel's management HTTP server and backed by the Camel Health Check API. Use these for Kubernetes liveness/readiness probes. |
+| `--no-health` | - | No | `false` | If `true`, the HTTP health check endpoints are disabled. |
 | `--mcp-tags` | `MCP_TAGS` | No | - | Comma-separated tags for MCP tool filtering. Only `ai-tool:` routes whose tags match will be exposed as MCP tools. If omitted, all `ai-tool:` routes are exposed. |
 
 **Example: Custom MCP Port**:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -4,16 +4,35 @@ This guide covers production deployment, monitoring, and operational best practi
 
 ## Health Checks
 
-The capability exposes an HTTP health endpoint via the built-in MCP server.
+The capability exposes HTTP health endpoints backed by the [Camel Health Check API](https://camel.apache.org/manual/health-check.html), served by Camel's built-in management HTTP server. They are intended for cluster/container orchestration (e.g., Kubernetes liveness and readiness probes).
 
-### MCP Server Health
+### HTTP Health Endpoints (Camel Health)
 
-- **Protocol:** HTTP
-- **Port:** Same as MCP server (default: 8080)
+- **Port:** 8081 by default (configurable with `--health-port`, disable with `--no-health`)
+- **Endpoints:**
+  - `/observe/health` — all health checks
+  - `/observe/health/live` — liveness checks only
+  - `/observe/health/ready` — readiness checks only (includes route and consumer checks)
+- **Response codes:** `200` when all checks are `UP`, `503` when any check is `DOWN`
+- **Detail level:** every check is reported individually; append `?exposureLevel=oneline` for a compact response
+
+Example response:
+
+```json
+{
+  "status": "UP",
+  "checks": [
+    { "name": "context", "status": "UP" },
+    { "name": "route:my-route", "status": "UP" }
+  ]
+}
+```
+
+The health endpoints become available once the Camel context starts (after resources are downloaded and routes are loaded). Account for that startup window in the probe timings below, or use a Kubernetes `startupProbe`.
 
 ### Kubernetes Health Checks
 
-Configure liveness and readiness probes using HTTP probes:
+Configure liveness and readiness probes using the HTTP health endpoints:
 
 ```yaml
 apiVersion: apps/v1
@@ -25,22 +44,24 @@ spec:
     spec:
       containers:
       - name: camel-capability
-        image: camel-integration-capability:latest
+        image: camel-integration-capability:0.2.0
         ports:
           - containerPort: 8080
             name: mcp
+          - containerPort: 8081
+            name: health
         livenessProbe:
           httpGet:
-            path: /
-            port: 8080
+            path: /observe/health/live
+            port: 8081
           initialDelaySeconds: 15
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 3
         readinessProbe:
           httpGet:
-            path: /
-            port: 8080
+            path: /observe/health/ready
+            port: 8081
           initialDelaySeconds: 10
           periodSeconds: 5
           timeoutSeconds: 3
@@ -51,6 +72,7 @@ spec:
 
 - **Liveness Probe:** `initialDelaySeconds: 15` allows time for Camel context initialization
 - **Readiness Probe:** `initialDelaySeconds: 10` allows time for route loading
+- On cold starts, dependency downloads can take 20-40 seconds before the health port is bound; increase `initialDelaySeconds`/`failureThreshold` or add a `startupProbe` if your routes pull many dependencies
 
 ## Resource Sizing
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -49,6 +49,8 @@ One of the following is required to provide routes:
 - `--init-from`: Git repository URL to clone during initialization (SSH or HTTPS format)
 - `--mcp-port`: Port for the MCP server (default: 8080)
 - `--mcp-tags`: Comma-separated tags for filtering which `ai-tool:` routes to expose
+- `--health-port`: HTTP port for health check endpoints `/observe/health`, `/observe/health/live`, `/observe/health/ready` (default: 8081)
+- `--no-health`: Disable the HTTP health check endpoints
 - `--name`: Service name (default: "camel")
 - `--retries`: Maximum download retries (default: 12)
 - `--wait-seconds`: Wait time between retries in seconds (default: 5)


### PR DESCRIPTION
Closes: #14 

As the issue analysis notes prescribe, the gRPC `CamelHealthProbe` is untouched — it remains the
internal protocol between the Wanaku router and capability services. The new HTTP endpoints are a
separate mechanism aimed at cluster/container orchestration.

## Summary by Sourcery

Add a separate configurable HTTP health interface for container and cluster orchestration while preserving the existing internal gRPC health protocol.

New Features:
- Add configurable Camel Health HTTP endpoints for overall, liveness, and readiness checks.
- Expose health-port and no-health runtime options and container configuration for orchestration probes.

Enhancements:
- Register and expose detailed Camel context, route, and consumer health checks through the management server.

Build:
- Add Camel Health and test-time Jackson dependencies and expose the health port in the container image.

Documentation:
- Document the health endpoints, CLI options, container port, and Kubernetes probe configuration.

Tests:
- Add integration coverage for health, liveness, readiness, route, and context check responses.

Chores:
- Clarify that the common module contains shared utilities and models.